### PR TITLE
[ETFE-437] Add Authentication to check for HMRC_EMCS_ORG enrolment and extract ERN

### DIFF
--- a/app/uk/gov/hmrc/emcstfefrontend/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/emcstfefrontend/config/AppConfig.scala
@@ -28,6 +28,9 @@ trait AppConfig {
 
   def welshLanguageSupportEnabled: Boolean
   def getReferenceDataStubFeatureSwitch(): Boolean
+
+  def loginUrl: String
+  def loginContinueUrl: String
 }
 
 @Singleton
@@ -42,4 +45,8 @@ class AppConfigImpl @Inject()(val servicesConfig: ServicesConfig, val config: Co
   def welshLanguageSupportEnabled: Boolean = config.getOptional[Boolean]("features.welsh-language-support").getOrElse(false)
 
   def getReferenceDataStubFeatureSwitch(): Boolean = servicesConfig.getBoolean("feature-switch.enable-reference-data-stub-source")
+
+  def loginUrl: String = servicesConfig.getString("urls.login")
+
+  def loginContinueUrl: String = servicesConfig.getString("urls.loginContinue")
 }

--- a/app/uk/gov/hmrc/emcstfefrontend/config/EnrolmentKeys.scala
+++ b/app/uk/gov/hmrc/emcstfefrontend/config/EnrolmentKeys.scala
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.emcstfefrontend.fixtures
+package uk.gov.hmrc.emcstfefrontend.config
 
-trait BaseFixtures {
+object EnrolmentKeys {
 
-  val ern = "SomeErn"
-  val testCredId = "cred1234567891"
-  val testInternalId = "int1234567891"
+  val EMCS_ENROLMENT = "HMRC_EMCS_ORG"
+  val ERN = "ExciseNumber"
+  val ACTIVATED = "activated"
+  val INACTIVE = "inactive"
 
 }

--- a/app/uk/gov/hmrc/emcstfefrontend/config/EnrolmentKeys.scala
+++ b/app/uk/gov/hmrc/emcstfefrontend/config/EnrolmentKeys.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.emcstfefrontend.config
 
 object EnrolmentKeys {
 
-  val EMCS_ENROLMENT = "HMRC_EMCS_ORG"
+  val EMCS_ENROLMENT = "HMRC-EMCS-ORG"
   val ERN = "ExciseNumber"
   val ACTIVATED = "activated"
   val INACTIVE = "inactive"

--- a/app/uk/gov/hmrc/emcstfefrontend/config/Module.scala
+++ b/app/uk/gov/hmrc/emcstfefrontend/config/Module.scala
@@ -17,11 +17,12 @@
 package uk.gov.hmrc.emcstfefrontend.config
 
 import com.google.inject.AbstractModule
+import uk.gov.hmrc.emcstfefrontend.controllers.predicates.{AuthAction, AuthActionImpl}
 
 class Module extends AbstractModule {
 
   override def configure(): Unit = {
-
     bind(classOf[AppConfig]).asEagerSingleton()
+    bind(classOf[AuthAction]).to(classOf[AuthActionImpl])
   }
 }

--- a/app/uk/gov/hmrc/emcstfefrontend/connectors/BaseConnectorUtils.scala
+++ b/app/uk/gov/hmrc/emcstfefrontend/connectors/BaseConnectorUtils.scala
@@ -16,15 +16,13 @@
 
 package uk.gov.hmrc.emcstfefrontend.connectors
 
-import play.api.Logger
 import play.api.libs.json.{JsError, JsSuccess, JsValue, Reads}
+import uk.gov.hmrc.emcstfefrontend.utils.Logging
 import uk.gov.hmrc.http.{HttpReads, HttpResponse}
 
 import scala.util.{Success, Try}
 
-trait BaseConnectorUtils[T] {
-
-  lazy val logger: Logger = Logger(this.getClass)
+trait BaseConnectorUtils[T] extends Logging {
 
   implicit val reads: Reads[T]
 
@@ -36,7 +34,7 @@ trait BaseConnectorUtils[T] {
       Try(response.json) match {
         case Success(json: JsValue) => parseResult(json)
         case _ =>
-          logger.warn("[KnownJsonResponse][validateJson] No JSON was returned")
+          logger.warn("[validateJson] No JSON was returned")
           None
       }
     }
@@ -45,7 +43,7 @@ trait BaseConnectorUtils[T] {
 
       case JsSuccess(value, _) => Some(value)
       case JsError(error) =>
-        logger.warn(s"[KnownJsonResponse][validateJson] Unable to parse JSON: $error")
+        logger.warn(s"[validateJson] Unable to parse JSON: $error")
         None
     }
   }

--- a/app/uk/gov/hmrc/emcstfefrontend/connectors/emcsTfe/EmcsTfeHttpParser.scala
+++ b/app/uk/gov/hmrc/emcstfefrontend/connectors/emcsTfe/EmcsTfeHttpParser.scala
@@ -32,11 +32,11 @@ trait EmcsTfeHttpParser[A] extends BaseConnectorUtils[A] {
         case OK => response.validateJson match {
           case Some(valid) => Right(valid)
           case None =>
-            logger.warn(s"[EmcsTfeHttpParser][read] Bad JSON response from emcs-tfe")
+            logger.warn(s"[read] Bad JSON response from emcs-tfe")
             Left(JsonValidationError)
         }
         case status =>
-          logger.warn(s"[EmcsTfeHttpParser][read] Unexpected status from emcs-tfe: $status")
+          logger.warn(s"[read] Unexpected status from emcs-tfe: $status")
           Left(UnexpectedDownstreamResponseError)
       }
     }

--- a/app/uk/gov/hmrc/emcstfefrontend/connectors/referenceData/ReferenceDataHttpParser.scala
+++ b/app/uk/gov/hmrc/emcstfefrontend/connectors/referenceData/ReferenceDataHttpParser.scala
@@ -33,11 +33,11 @@ trait ReferenceDataHttpParser[A] extends BaseConnectorUtils[A] {
         case OK => response.validateJson match {
           case Some(valid) => Right(valid)
           case None =>
-            logger.warn(s"[ReferenceDataHttpParser][read] Bad JSON response from reference-data")
+            logger.warn(s"[read] Bad JSON response from reference-data")
             Left(JsonValidationError)
         }
         case status =>
-          logger.warn(s"[ReferenceDataHttpParser][read] Unexpected status from reference-data: $status")
+          logger.warn(s"[read] Unexpected status from reference-data: $status")
           Left(UnexpectedDownstreamResponseError)
       }
     }

--- a/app/uk/gov/hmrc/emcstfefrontend/controllers/HelloWorldController.scala
+++ b/app/uk/gov/hmrc/emcstfefrontend/controllers/HelloWorldController.scala
@@ -35,7 +35,7 @@ class HelloWorldController @Inject()(
   extends FrontendController(mcc) {
 
   def helloWorld(): Action[AnyContent] = Action.async { implicit request =>
-    val response = service.getMessage map {
+    val response = service.getMessage() map {
       case (referenceDataResponse, emcsTfeResponse) => Ok(helloWorldPage(referenceDataResponse, emcsTfeResponse))
     }
 

--- a/app/uk/gov/hmrc/emcstfefrontend/controllers/ModeOfTransportController.scala
+++ b/app/uk/gov/hmrc/emcstfefrontend/controllers/ModeOfTransportController.scala
@@ -18,6 +18,7 @@ package uk.gov.hmrc.emcstfefrontend.controllers
 
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.emcstfefrontend.config.ErrorHandler
+import uk.gov.hmrc.emcstfefrontend.controllers.predicates.AuthAction
 import uk.gov.hmrc.emcstfefrontend.services.ModeOfTransportService
 import uk.gov.hmrc.emcstfefrontend.views.html.ModeOfTransportPage
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -26,15 +27,14 @@ import javax.inject.{Inject, Singleton}
 import scala.concurrent.ExecutionContext
 
 @Singleton
-class ModeOfTransportController @Inject()(
-                                      mcc: MessagesControllerComponents,
-                                      service: ModeOfTransportService,
-                                      modeOfTransportPage: ModeOfTransportPage,
-                                      errorHandler: ErrorHandler,
-                                      implicit val executionContext: ExecutionContext)
-  extends FrontendController(mcc) {
+class ModeOfTransportController @Inject()(mcc: MessagesControllerComponents,
+                                          service: ModeOfTransportService,
+                                          modeOfTransportPage: ModeOfTransportPage,
+                                          errorHandler: ErrorHandler,
+                                          authAction: AuthAction
+                                         )(implicit val executionContext: ExecutionContext) extends FrontendController(mcc) {
 
-  def modeOfTransport(): Action[AnyContent] = Action.async { implicit request =>
+  def modeOfTransport(): Action[AnyContent] = authAction.async { implicit request =>
 
     service.getOtherDataReferenceList map {
       case Right(response) =>

--- a/app/uk/gov/hmrc/emcstfefrontend/controllers/ViewMovementController.scala
+++ b/app/uk/gov/hmrc/emcstfefrontend/controllers/ViewMovementController.scala
@@ -34,9 +34,9 @@ class ViewMovementController @Inject()(mcc: MessagesControllerComponents,
                                        authAction: AuthAction
                                       )(implicit val executionContext: ExecutionContext) extends FrontendController(mcc) {
 
-  def viewMovement(exciseRegistrationNumber: String, arc: String): Action[AnyContent] = authAction.async {
-    implicit request => {
-      connector.getMovement(exciseRegistrationNumber = exciseRegistrationNumber, arc = arc).map {
+  def viewMovement(exciseRegistrationNumber: String, arc: String): Action[AnyContent] = authAction.async { implicit request =>
+    authAction.checkErnMatchesRequest(exciseRegistrationNumber) {
+      connector.getMovement(exciseRegistrationNumber, arc).map {
         case Right(response) => Ok(viewMovementPage(arc, response))
         case Left(_) => InternalServerError(errorHandler.standardErrorTemplate())
       }

--- a/app/uk/gov/hmrc/emcstfefrontend/controllers/ViewMovementController.scala
+++ b/app/uk/gov/hmrc/emcstfefrontend/controllers/ViewMovementController.scala
@@ -19,6 +19,7 @@ package uk.gov.hmrc.emcstfefrontend.controllers
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.emcstfefrontend.config.ErrorHandler
 import uk.gov.hmrc.emcstfefrontend.connectors.emcsTfe.GetMovementConnector
+import uk.gov.hmrc.emcstfefrontend.controllers.predicates.AuthAction
 import uk.gov.hmrc.emcstfefrontend.views.html.ViewMovementPage
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
@@ -26,15 +27,14 @@ import javax.inject.{Inject, Singleton}
 import scala.concurrent.ExecutionContext
 
 @Singleton
-class ViewMovementController @Inject()(
-                                        mcc: MessagesControllerComponents,
-                                        connector: GetMovementConnector,
-                                        viewMovementPage: ViewMovementPage,
-                                        errorHandler: ErrorHandler,
-                                        implicit val executionContext: ExecutionContext)
-  extends FrontendController(mcc) {
+class ViewMovementController @Inject()(mcc: MessagesControllerComponents,
+                                       connector: GetMovementConnector,
+                                       viewMovementPage: ViewMovementPage,
+                                       errorHandler: ErrorHandler,
+                                       authAction: AuthAction
+                                      )(implicit val executionContext: ExecutionContext) extends FrontendController(mcc) {
 
-  def viewMovement(exciseRegistrationNumber: String, arc: String): Action[AnyContent] = Action.async {
+  def viewMovement(exciseRegistrationNumber: String, arc: String): Action[AnyContent] = authAction.async {
     implicit request => {
       connector.getMovement(exciseRegistrationNumber = exciseRegistrationNumber, arc = arc).map {
         case Right(response) => Ok(viewMovementPage(arc, response))

--- a/app/uk/gov/hmrc/emcstfefrontend/controllers/ViewMovementListController.scala
+++ b/app/uk/gov/hmrc/emcstfefrontend/controllers/ViewMovementListController.scala
@@ -19,6 +19,7 @@ package uk.gov.hmrc.emcstfefrontend.controllers
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.emcstfefrontend.config.ErrorHandler
 import uk.gov.hmrc.emcstfefrontend.connectors.emcsTfe.GetMovementListConnector
+import uk.gov.hmrc.emcstfefrontend.controllers.predicates.AuthAction
 import uk.gov.hmrc.emcstfefrontend.views.html.ViewMovementListPage
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
@@ -30,9 +31,10 @@ class ViewMovementListController @Inject()(mcc: MessagesControllerComponents,
                                            connector: GetMovementListConnector,
                                            viewMovementListPage: ViewMovementListPage,
                                            errorHandler: ErrorHandler,
-                                           implicit val executionContext: ExecutionContext) extends FrontendController(mcc) {
+                                           authAction: AuthAction
+                                          )(implicit val executionContext: ExecutionContext) extends FrontendController(mcc) {
 
-  def viewMovementList(exciseRegistrationNumber: String): Action[AnyContent] = Action.async { implicit request =>
+  def viewMovementList(exciseRegistrationNumber: String): Action[AnyContent] = authAction.async { implicit request =>
     connector.getMovementList(exciseRegistrationNumber).map {
       case Right(movementList) => Ok(viewMovementListPage(exciseRegistrationNumber, movementList))
       case Left(_) => InternalServerError(errorHandler.internalServerErrorTemplate)

--- a/app/uk/gov/hmrc/emcstfefrontend/controllers/ViewMovementListController.scala
+++ b/app/uk/gov/hmrc/emcstfefrontend/controllers/ViewMovementListController.scala
@@ -35,9 +35,11 @@ class ViewMovementListController @Inject()(mcc: MessagesControllerComponents,
                                           )(implicit val executionContext: ExecutionContext) extends FrontendController(mcc) {
 
   def viewMovementList(exciseRegistrationNumber: String): Action[AnyContent] = authAction.async { implicit request =>
-    connector.getMovementList(exciseRegistrationNumber).map {
-      case Right(movementList) => Ok(viewMovementListPage(exciseRegistrationNumber, movementList))
-      case Left(_) => InternalServerError(errorHandler.internalServerErrorTemplate)
+    authAction.checkErnMatchesRequest(exciseRegistrationNumber) {
+      connector.getMovementList(exciseRegistrationNumber).map {
+        case Right(movementList) => Ok(viewMovementListPage(exciseRegistrationNumber, movementList))
+        case Left(_) => InternalServerError(errorHandler.internalServerErrorTemplate)
+      }
     }
   }
 }

--- a/app/uk/gov/hmrc/emcstfefrontend/controllers/errors/UnauthorisedController.scala
+++ b/app/uk/gov/hmrc/emcstfefrontend/controllers/errors/UnauthorisedController.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.emcstfefrontend.controllers.errors
+
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import uk.gov.hmrc.emcstfefrontend.config.ErrorHandler
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.ExecutionContext
+
+@Singleton
+class UnauthorisedController @Inject()(mcc: MessagesControllerComponents,
+                                       errorHandler: ErrorHandler,
+                                       implicit val executionContext: ExecutionContext) extends FrontendController(mcc) {
+
+  def unauthorised(): Action[AnyContent] = Action { implicit request =>
+    Unauthorized(errorHandler.standardErrorTemplate(
+      pageTitle = "errors.unauthorised.title",
+      heading = "errors.unauthorised.heading",
+      message = "errors.unauthorised.message"
+    ))
+  }
+
+}

--- a/app/uk/gov/hmrc/emcstfefrontend/controllers/predicates/AuthAction.scala
+++ b/app/uk/gov/hmrc/emcstfefrontend/controllers/predicates/AuthAction.scala
@@ -96,10 +96,10 @@ class AuthActionImpl @Inject()(override val authConnector: AuthConnector,
             Future.successful(Redirect(controllers.errors.routes.UnauthorisedController.unauthorised()))
         }
       case Some(enrolment) if !enrolment.isActivated =>
-        logger.debug(s"[checkOrganisationEpayeEnrolment] ${EnrolmentKeys.EMCS_ENROLMENT} enrolment found but not activated")
+        logger.debug(s"[checkOrganisationEMCSEnrolment] ${EnrolmentKeys.EMCS_ENROLMENT} enrolment found but not activated")
         Future.successful(Redirect(controllers.errors.routes.UnauthorisedController.unauthorised()))
       case _ =>
-        logger.debug(s"[checkOrganisationEpayeEnrolment] No ${EnrolmentKeys.EMCS_ENROLMENT} enrolment found")
+        logger.debug(s"[checkOrganisationEMCSEnrolment] No ${EnrolmentKeys.EMCS_ENROLMENT} enrolment found")
         Future.successful(Redirect(controllers.errors.routes.UnauthorisedController.unauthorised()))
     }
 }

--- a/app/uk/gov/hmrc/emcstfefrontend/controllers/predicates/AuthAction.scala
+++ b/app/uk/gov/hmrc/emcstfefrontend/controllers/predicates/AuthAction.scala
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.emcstfefrontend.controllers.predicates
+
+import com.google.inject.Inject
+import play.api.mvc.Results._
+import play.api.mvc._
+import uk.gov.hmrc.auth.core.AffinityGroup.Organisation
+import uk.gov.hmrc.auth.core._
+import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals
+import uk.gov.hmrc.auth.core.retrieve.~
+import uk.gov.hmrc.emcstfefrontend.config.{AppConfig, EnrolmentKeys}
+import uk.gov.hmrc.emcstfefrontend.controllers
+import uk.gov.hmrc.emcstfefrontend.models.auth.UserRequest
+import uk.gov.hmrc.emcstfefrontend.utils.Logging
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.play.http.HeaderCarrierConverter
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait AuthAction extends ActionBuilder[UserRequest, AnyContent] with ActionFunction[Request, UserRequest]
+
+class AuthenticatedUserAction @Inject()(override val authConnector: AuthConnector,
+                                        config: AppConfig,
+                                        val parser: BodyParsers.Default
+                                       )(implicit val executionContext: ExecutionContext) extends AuthAction with AuthorisedFunctions with Logging {
+
+  override def invokeBlock[A](request: Request[A], block: UserRequest[A] => Future[Result]): Future[Result] = {
+
+    implicit val hc: HeaderCarrier = HeaderCarrierConverter.fromRequestAndSession(
+      session = request.session,
+      request = request
+    )
+
+    implicit val req = request
+
+    authorised().retrieve(Retrievals.affinityGroup and Retrievals.allEnrolments and Retrievals.internalId and Retrievals.credentials) {
+
+      case Some(Organisation) ~ enrolments ~ Some(internalId) ~ Some(credentials) =>
+        checkOrganisationEMCSEnrolment(enrolments, internalId, credentials.providerId)(block)
+
+      case Some(Organisation) ~ _ ~ None ~ _ =>
+        logger.warn("[AuthenticatedIdentifierAction][invokeBlock] InternalId could not be retrieved from Auth")
+        Future.successful(Redirect(controllers.errors.routes.UnauthorisedController.unauthorised()))
+
+      case Some(Organisation) ~ _ ~ _ ~ None =>
+        logger.warn("[AuthenticatedIdentifierAction][invokeBlock] Credentials could not be retrieved from Auth")
+        Future.successful(Redirect(controllers.errors.routes.UnauthorisedController.unauthorised()))
+
+      case Some(affinityGroup) ~ _ ~ _ ~ _ =>
+        logger.warn(s"[AuthenticatedIdentifierAction][invokeBlock] User has incompatible AffinityGroup of '$affinityGroup'")
+        Future.successful(Redirect(controllers.errors.routes.UnauthorisedController.unauthorised()))
+
+      case _ =>
+        logger.warn(s"[AuthenticatedIdentifierAction][invokeBlock] User has no AffinityGroup")
+        Future.successful(Redirect(controllers.errors.routes.UnauthorisedController.unauthorised()))
+
+    } recover {
+      case _: NoActiveSession =>
+        Redirect(config.loginUrl, Map("continue" -> Seq(config.loginContinueUrl)))
+      case x: AuthorisationException =>
+        logger.debug(s"[AuthenticatedIdentifierAction][invokeBlock] Authorisation Exception ${x.reason}")
+        Redirect(controllers.errors.routes.UnauthorisedController.unauthorised())
+    }
+  }
+
+  private def checkOrganisationEMCSEnrolment[A](enrolments: Enrolments,
+                                                internalId: String,
+                                                credId: String
+                                               )(block: UserRequest[A] => Future[Result])
+                                               (implicit request: Request[A]): Future[Result] =
+    enrolments.enrolments.find(_.key == EnrolmentKeys.EMCS_ENROLMENT) match {
+      case Some(enrolment) if enrolment.isActivated =>
+        enrolment.identifiers.find(_.key == EnrolmentKeys.ERN).map(_.value) match {
+          case Some(ern) =>
+            block(UserRequest(request, ern, internalId, credId))
+          case None =>
+            logger.error(s"[AuthenticatedIdentifierAction][checkOrganisationEMCSEnrolment] Could not find ${EnrolmentKeys.ERN} from the ${EnrolmentKeys.EMCS_ENROLMENT} enrolment")
+            Future.successful(Redirect(controllers.errors.routes.UnauthorisedController.unauthorised()))
+        }
+      case Some(enrolment) if !enrolment.isActivated =>
+        logger.debug(s"[AuthenticatedIdentifierAction][checkOrganisationEpayeEnrolment] ${EnrolmentKeys.EMCS_ENROLMENT} enrolment found but not activated")
+        Future.successful(Redirect(controllers.errors.routes.UnauthorisedController.unauthorised()))
+      case _ =>
+        logger.debug(s"[AuthenticatedIdentifierAction][checkOrganisationEpayeEnrolment] No ${EnrolmentKeys.EMCS_ENROLMENT} enrolment found")
+        Future.successful(Redirect(controllers.errors.routes.UnauthorisedController.unauthorised()))
+    }
+}

--- a/app/uk/gov/hmrc/emcstfefrontend/models/auth/UserRequest.scala
+++ b/app/uk/gov/hmrc/emcstfefrontend/models/auth/UserRequest.scala
@@ -16,9 +16,10 @@
 
 package uk.gov.hmrc.emcstfefrontend.models.auth
 
-import play.api.mvc.{Request, WrappedRequest}
+import play.api.i18n.MessagesApi
+import play.api.mvc.{MessagesRequestHeader, PreferredMessagesProvider, Request, WrappedRequest}
 
 case class UserRequest[A](request: Request[A],
                           ern: String,
                           internalId: String,
-                          credId: String) extends WrappedRequest[A](request)
+                          credId: String)(implicit val messagesApi: MessagesApi) extends WrappedRequest[A](request) with PreferredMessagesProvider with MessagesRequestHeader

--- a/app/uk/gov/hmrc/emcstfefrontend/models/auth/UserRequest.scala
+++ b/app/uk/gov/hmrc/emcstfefrontend/models/auth/UserRequest.scala
@@ -14,12 +14,11 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.emcstfefrontend.fixtures
+package uk.gov.hmrc.emcstfefrontend.models.auth
 
-trait BaseFixtures {
+import play.api.mvc.{Request, WrappedRequest}
 
-  val ern = "SomeErn"
-  val testCredId = "cred1234567891"
-  val testInternalId = "int1234567891"
-
-}
+case class UserRequest[A](request: Request[A],
+                          ern: String,
+                          internalId: String,
+                          credId: String) extends WrappedRequest[A](request)

--- a/app/uk/gov/hmrc/emcstfefrontend/utils/Logging.scala
+++ b/app/uk/gov/hmrc/emcstfefrontend/utils/Logging.scala
@@ -16,8 +16,29 @@
 
 package uk.gov.hmrc.emcstfefrontend.utils
 
-import play.api.Logger
+import org.slf4j.{Logger, LoggerFactory}
+import play.api.{LoggerLike, MarkerContext}
 
 trait Logging {
-  lazy val logger: Logger = Logger(this.getClass)
+
+  private lazy val loggerName: String = this.getClass.getName.stripSuffix("$")
+  private lazy val className: String = this.getClass.getSimpleName.stripSuffix("$")
+
+  val logger: LoggerLike = new LoggerLike {
+
+    private lazy val prefixLog: String => String = msg =>
+      s"[$className]${if (msg.startsWith("[")) msg else " " + msg}"
+
+    override val logger: Logger = LoggerFactory.getLogger(loggerName)
+
+    override def debug(message: => String)(implicit mc: MarkerContext): Unit = super.debug(prefixLog(message))
+    override def info(message: => String)(implicit mc: MarkerContext): Unit = super.info(prefixLog(message))
+    override def warn(message: => String)(implicit mc: MarkerContext): Unit = super.warn(prefixLog(message))
+    override def error(message: => String)(implicit mc: MarkerContext): Unit = super.error(prefixLog(message))
+
+    override def debug(message: => String, e: => Throwable)(implicit mc: MarkerContext): Unit = super.debug(prefixLog(message), e)
+    override def info(message: => String, e: => Throwable)(implicit mc: MarkerContext): Unit = super.info(prefixLog(message), e)
+    override def warn(message: => String, e: => Throwable)(implicit mc: MarkerContext): Unit = super.warn(prefixLog(message), e)
+    override def error(message: => String, e: => Throwable)(implicit mc: MarkerContext): Unit = super.error(prefixLog(message), e)
+  }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ import uk.gov.hmrc.versioning.SbtGitVersioning.autoImport.majorVersion
 
 val appName = "emcs-tfe-frontend"
 
-val silencerVersion = "1.7.7"
+val silencerVersion = "1.7.12"
 
 lazy val ItTest = config("it") extend Test
 
@@ -14,9 +14,9 @@ lazy val microservice = Project(appName, file("."))
   .disablePlugins(JUnitXmlReportPlugin) //Required to prevent https://github.com/scalatest/scalatest/issues/1427
   .settings(
     majorVersion := 0,
-    scalaVersion := "2.12.15",
+    scalaVersion := "2.13.8",
     libraryDependencies ++= AppDependencies.compile ++ AppDependencies.test,
-    pipelineStages in Assets := Seq(gzip),
+    Assets / pipelineStages := Seq(gzip),
     // ***************
     // Use the silencer plugin to suppress warnings
     scalacOptions += "-P:silencer:pathFilters=routes",
@@ -30,7 +30,6 @@ lazy val microservice = Project(appName, file("."))
     scalacOptions += "-Wconf:cat=unused-imports&src=html/.*:s",
     scalacOptions += "-Wconf:cat=unused-imports&src=routes/.*:s"
   )
-  .settings(publishingSettings: _*)
   .configs(ItTest)
   .settings(inConfig(ItTest)(Defaults.itSettings): _*)
   .settings(

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -1,9 +1,15 @@
 # microservice specific routes
 
 ->          /hmrc-frontend                                     hmrcfrontend.Routes
+->          /errors                                            error.Routes
+
+GET         /assets/*file                                      controllers.Assets.versioned(path = "/public", file: Asset)
+
 GET         /                                                  uk.gov.hmrc.emcstfefrontend.controllers.HelloWorldController.helloWorld
+
 GET         /mode-of-transport                                 uk.gov.hmrc.emcstfefrontend.controllers.ModeOfTransportController.modeOfTransport
 POST        /mode-of-transport                                 uk.gov.hmrc.emcstfefrontend.controllers.ModeOfTransportController.onSubmit
+
 GET         /consignment/:exciseRegistrationNumber/:arc        uk.gov.hmrc.emcstfefrontend.controllers.ViewMovementController.viewMovement(exciseRegistrationNumber, arc)
+
 GET         /movements-in/:exciseRegistrationNumber            uk.gov.hmrc.emcstfefrontend.controllers.ViewMovementListController.viewMovementList(exciseRegistrationNumber)
-GET         /assets/*file                                      controllers.Assets.versioned(path = "/public", file: Asset)

--- a/conf/application-json-logger.xml
+++ b/conf/application-json-logger.xml
@@ -5,6 +5,8 @@
         <encoder class="uk.gov.hmrc.play.logging.JsonEncoder"/>
     </appender>
 
+    <logger name="uk.gov.hmrc.emcstfefrontend" level="DEBUG"/>
+
     <root level="WARN">
         <appender-ref ref="STDOUT"/>
     </root>

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -44,6 +44,9 @@ play.http.errorHandler = "uk.gov.hmrc.emcstfefrontend.config.ErrorHandler"
 # Play Modules
 play.modules.enabled += "uk.gov.hmrc.emcstfefrontend.config.Module"
 
+# Auth Module
+play.modules.enabled += "uk.gov.hmrc.play.bootstrap.AuthModule"
+
 microservice {
   metrics {
     graphite {
@@ -55,6 +58,11 @@ microservice {
   }
 
   services {
+    auth {
+      protocol = http
+      host = localhost
+      port = 8500
+    }
     reference-data {
       protocol = http
       host = localhost

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -102,6 +102,11 @@ controllers {
   }
 }
 
+urls {
+  login = "http://localhost:9949/auth-login-stub/gg-sign-in"
+  loginContinue = "http://localhost:8310/emcs-tfe"
+}
+
 feature-switch {
   enable-reference-data-stub-source = true
 }

--- a/conf/error.routes
+++ b/conf/error.routes
@@ -1,0 +1,3 @@
+# microservice specific routes
+
+GET         /unauthorised               uk.gov.hmrc.emcstfefrontend.controllers.errors.UnauthorisedController.unauthorised()

--- a/conf/logback-test.xml
+++ b/conf/logback-test.xml
@@ -50,6 +50,7 @@
 
 
     <logger name="application" level="INFO"/>
+    <logger name="uk.gov.hmrc.emcstfefrontend" level="DEBUG"/>
 
     <logger name="connector" level="ERROR">
         <appender-ref ref="STDOUT"/>

--- a/conf/logback-test.xml
+++ b/conf/logback-test.xml
@@ -2,21 +2,21 @@
 <configuration>
 
     <appender name="FILE" class="ch.qos.logback.core.FileAppender">
-        <file>logs/microservice.log</file>
+        <file>logs/emcs-tfe-frontend.log</file>
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-            <pattern>%date{ISO8601} level=[%level] logger=[%logger] thread=[%thread] message=[%message] %replace(exception=[%xException]){'^exception=\[\]$',''}%n</pattern>
+            <pattern>[%highlight(%.-4level)] %message %replace(exception=[%xException]){'^exception=\[\]$',''} %date{ISO8601} %n</pattern>
         </encoder>
     </appender>
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-            <pattern>%date{ISO8601} level=[%level] logger=[%logger] thread=[%thread] rid=[%X{X-Request-ID}] user=[%X{Authorization}] message=[%message] %replace(exception=[%xException]){'^exception=\[\]$',''}%n</pattern>
+            <pattern>[%highlight(%.-4level)] %message %replace(exception=[%xException]){'^exception=\[\]$',''} %date{ISO8601} %n</pattern>
         </encoder>
     </appender>
 
     <appender name="STDOUT_IGNORE_NETTY" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-            <pattern>%date{ISO8601} level=[%level] logger=[%logger] thread=[%thread] rid=[not-available] user=[not-available] message=[%message] %replace(exception=[%xException]){'^exception=\[\]$',''}%n</pattern>
+            <pattern>[%highlight(%.-4level)] %message %replace(exception=[%xException]){'^exception=\[\]$',''} %date{ISO8601} %n</pattern>
         </encoder>
     </appender>
 
@@ -56,7 +56,8 @@
         <appender-ref ref="STDOUT"/>
     </logger>
 
-    <root level="INFO">
+    <root level="ERROR">
         <appender-ref ref="FILE"/>
+        <appender-ref ref="STDOUT"/>
     </root>
 </configuration>

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -45,7 +45,7 @@
 
     <logger name="com.google.inject" level="INFO"/>
 
-    <logger name="uk.gov" level="INFO"/>
+    <logger name="uk.gov.hmrc.emcstfefrontend" level="DEBUG"/>
 
     <logger name="application" level="DEBUG"/>
 

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -4,19 +4,19 @@
     <appender name="FILE" class="ch.qos.logback.core.FileAppender">
         <file>logs/emcs-tfe-frontend.log</file>
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-            <pattern>%date{ISO8601} level=[%level] logger=[%logger] thread=[%thread] message=[%message] %replace(exception=[%xException]){'^exception=\[\]$',''}%n</pattern>
+            <pattern>[%highlight(%.-4level)] %message %replace(exception=[%xException]){'^exception=\[\]$',''} %date{ISO8601} %n</pattern>
         </encoder>
     </appender>
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-            <pattern>%date{ISO8601} level=[%level] logger=[%logger] thread=[%thread] rid=[%X{X-Request-ID}] user=[%X{Authorization}] message=[%message] %replace(exception=[%xException]){'^exception=\[\]$',''}%n</pattern>
+            <pattern>[%highlight(%.-4level)] %message %replace(exception=[%xException]){'^exception=\[\]$',''} %date{ISO8601} %n</pattern>
         </encoder>
     </appender>
 
     <appender name="STDOUT_IGNORE_NETTY" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-            <pattern>%date{ISO8601} level=[%level] logger=[%logger] thread=[%thread] rid=[not-available] user=[not-available] message=[%message] %replace(exception=[%xException]){'^exception=\[\]$',''}%n</pattern>
+            <pattern>[%highlight(%.-4level)] %message %replace(exception=[%xException]){'^exception=\[\]$',''} %date{ISO8601} %n</pattern>
         </encoder>
     </appender>
 
@@ -47,13 +47,11 @@
 
     <logger name="uk.gov.hmrc.emcstfefrontend" level="DEBUG"/>
 
-    <logger name="application" level="DEBUG"/>
-
-    <logger name="connector" level="TRACE">
+    <logger name="connector" level="ERROR">
         <appender-ref ref="STDOUT"/>
     </logger>
 
-    <root level="INFO">
+    <root level="ERROR">
         <appender-ref ref="FILE"/>
         <appender-ref ref="STDOUT"/>
     </root>

--- a/conf/messages
+++ b/conf/messages
@@ -26,3 +26,7 @@ viewMovementList.title = Movements in
 viewMovementList.heading = Movements in
 viewMovementList.table.arc = ARC
 viewMovementList.table.consignor = Consignor
+
+errors.unauthorised.title = Unauthorised
+errors.unauthorised.heading = Unauthorised
+errors.unauthorised.message = You are not authorised to access this service

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -7,3 +7,7 @@ viewMovementList.title = Movements in
 viewMovementList.heading = Movements in
 viewMovementList.table.arc = ARC
 viewMovementList.table.consignor = Consignor
+
+errors.unauthorised.title = Unauthorised
+errors.unauthorised.heading = Unauthorised
+errors.unauthorised.message = You are not authorised to access this service

--- a/it/uk/gov/hmrc/emcstfefrontend/ViewMovementIntegrationSpec.scala
+++ b/it/uk/gov/hmrc/emcstfefrontend/ViewMovementIntegrationSpec.scala
@@ -17,11 +17,11 @@
 package uk.gov.hmrc.emcstfefrontend
 
 import com.github.tomakehurst.wiremock.stubbing.StubMapping
-import play.api.http.Status
+import play.api.http.{HeaderNames, Status}
 import play.api.libs.json.{JsValue, Json}
 import play.api.libs.ws.{WSRequest, WSResponse}
 import uk.gov.hmrc.emcstfefrontend.fixtures.ModeOfTransportListFixture
-import uk.gov.hmrc.emcstfefrontend.stubs.DownstreamStub
+import uk.gov.hmrc.emcstfefrontend.stubs.{AuthStub, DownstreamStub}
 import uk.gov.hmrc.emcstfefrontend.support.IntegrationBaseSpec
 
 import scala.xml.Elem
@@ -41,74 +41,94 @@ class ViewMovementIntegrationSpec extends IntegrationBaseSpec with ModeOfTranspo
     }
   }
 
-  "Calling the mode of transport page" should {
-    "return a success page" when {
-      "all downstream calls are successful" in new Test {
+  "Calling the mode of transport page" when {
+
+    "user is unauthorised" must {
+      "redirect to the Unauthorised controller" in new Test {
+
         override def setupStubs(): StubMapping = {
-          DownstreamStub.onSuccess(DownstreamStub.GET, emcsTfeUri, Status.OK, Json.parse(
-            """{
-              |  "localReferenceNumber": "MyLrn",
-              |  "eadStatus": "MyEadStatus",
-              |  "consignorName": "MyConsignor",
-              |  "dateOfDispatch": "2010-03-04",
-              |  "journeyTime": "MyJourneyTime",
-              |  "numberOfItems": 0
-              |}""".stripMargin))
+          AuthStub.unauthorised()
         }
 
         val response: WSResponse = await(request().get())
-        response.status shouldBe Status.OK
-        response.body should include("Administrative reference code")
-        response.body should include("my-arc")
+        response.status shouldBe Status.SEE_OTHER
+        response.header(HeaderNames.LOCATION) shouldBe Some(controllers.errors.routes.UnauthorisedController.unauthorised().url)
       }
     }
-    "return an error page" when {
-      "downstream call returns unexpected JSON" in new Test {
-        val emcsTfeResponseBody: JsValue = Json.parse(
-          s"""
-             |{
-             |   "field": "test message"
-             |}
-             |""".stripMargin
-        )
 
-        override def setupStubs(): StubMapping = {
-          DownstreamStub.onSuccess(DownstreamStub.GET, emcsTfeUri, Status.OK, emcsTfeResponseBody)
+    "user is authorised" when {
+      "return a success page" when {
+        "all downstream calls are successful" in new Test {
+          override def setupStubs(): StubMapping = {
+            AuthStub.authorised()
+            DownstreamStub.onSuccess(DownstreamStub.GET, emcsTfeUri, Status.OK, Json.parse(
+              """{
+                |  "localReferenceNumber": "MyLrn",
+                |  "eadStatus": "MyEadStatus",
+                |  "consignorName": "MyConsignor",
+                |  "dateOfDispatch": "2010-03-04",
+                |  "journeyTime": "MyJourneyTime",
+                |  "numberOfItems": 0
+                |}""".stripMargin))
+          }
+
+          val response: WSResponse = await(request().get())
+          response.status shouldBe Status.OK
+          response.body should include("Administrative reference code")
+          response.body should include("my-arc")
         }
-
-        val response: WSResponse = await(request().get())
-        response.status shouldBe Status.INTERNAL_SERVER_ERROR
-        response.body should include("Sorry, we’re experiencing technical difficulties")
       }
+      "return an error page" when {
+        "downstream call returns unexpected JSON" in new Test {
+          val emcsTfeResponseBody: JsValue = Json.parse(
+            s"""
+               |{
+               |   "field": "test message"
+               |}
+               |""".stripMargin
+          )
 
-      "downstream call returns something other than JSON" in new Test {
-        val emcsTfeResponseBody: Elem = <message>test message</message>
+          override def setupStubs(): StubMapping = {
+            AuthStub.authorised()
+            DownstreamStub.onSuccess(DownstreamStub.GET, emcsTfeUri, Status.OK, emcsTfeResponseBody)
+          }
 
-        override def setupStubs(): StubMapping = {
-          DownstreamStub.onSuccess(DownstreamStub.GET, emcsTfeUri, Status.OK, emcsTfeResponseBody)
+          val response: WSResponse = await(request().get())
+          response.status shouldBe Status.INTERNAL_SERVER_ERROR
+          response.body should include("Sorry, we’re experiencing technical difficulties")
         }
 
-        val response: WSResponse = await(request().get())
-        response.status shouldBe Status.INTERNAL_SERVER_ERROR
-        response.header("Content-Type") shouldBe Some("text/html; charset=UTF-8")
-        response.body should include("Sorry, we’re experiencing technical difficulties")
-      }
-      "downstream call returns a non-200 HTTP response" in new Test {
-        val emcsTfeResponseBody: JsValue = Json.parse(
-          s"""
-             |{
-             |   "message": "test message"
-             |}
-             |""".stripMargin
-        )
+        "downstream call returns something other than JSON" in new Test {
+          val emcsTfeResponseBody: Elem = <message>test message</message>
 
-        override def setupStubs(): StubMapping = {
-          DownstreamStub.onSuccess(DownstreamStub.GET, emcsTfeUri, Status.INTERNAL_SERVER_ERROR, emcsTfeResponseBody)
+          override def setupStubs(): StubMapping = {
+            AuthStub.authorised()
+            DownstreamStub.onSuccess(DownstreamStub.GET, emcsTfeUri, Status.OK, emcsTfeResponseBody)
+          }
+
+          val response: WSResponse = await(request().get())
+          response.status shouldBe Status.INTERNAL_SERVER_ERROR
+          response.header("Content-Type") shouldBe Some("text/html; charset=UTF-8")
+          response.body should include("Sorry, we’re experiencing technical difficulties")
         }
+        "downstream call returns a non-200 HTTP response" in new Test {
+          val emcsTfeResponseBody: JsValue = Json.parse(
+            s"""
+               |{
+               |   "message": "test message"
+               |}
+               |""".stripMargin
+          )
 
-        val response: WSResponse = await(request().get())
-        response.status shouldBe Status.INTERNAL_SERVER_ERROR
-        response.body should include("Sorry, we’re experiencing technical difficulties")
+          override def setupStubs(): StubMapping = {
+            AuthStub.authorised()
+            DownstreamStub.onSuccess(DownstreamStub.GET, emcsTfeUri, Status.INTERNAL_SERVER_ERROR, emcsTfeResponseBody)
+          }
+
+          val response: WSResponse = await(request().get())
+          response.status shouldBe Status.INTERNAL_SERVER_ERROR
+          response.body should include("Sorry, we’re experiencing technical difficulties")
+        }
       }
     }
   }

--- a/it/uk/gov/hmrc/emcstfefrontend/ViewMovementListIntegrationSpec.scala
+++ b/it/uk/gov/hmrc/emcstfefrontend/ViewMovementListIntegrationSpec.scala
@@ -57,7 +57,19 @@ class ViewMovementListIntegrationSpec extends IntegrationBaseSpec with MovementL
       }
     }
 
-    "user is authorised" when {
+    "user is authorised" should {
+
+      "return unauthorised" when {
+        "ERN from the URL does not match the ERN of the logged in User" in new Test {
+          override def setupStubs(): StubMapping = {
+            AuthStub.authorised("wrongErn")
+          }
+
+          val response: WSResponse = await(request().get())
+          response.status shouldBe Status.SEE_OTHER
+          response.header(HeaderNames.LOCATION) shouldBe Some(controllers.errors.routes.UnauthorisedController.unauthorised().url)
+        }
+      }
 
       "return a success page" when {
 

--- a/it/uk/gov/hmrc/emcstfefrontend/stubs/AuthStub.scala
+++ b/it/uk/gov/hmrc/emcstfefrontend/stubs/AuthStub.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.emcstfefrontend.stubs
+
+import com.github.tomakehurst.wiremock.stubbing.StubMapping
+import play.api.http.Status.{OK, UNAUTHORIZED}
+import play.api.libs.json.{JsValue, Json}
+import uk.gov.hmrc.auth.core.AffinityGroup
+import uk.gov.hmrc.auth.core.AffinityGroup.Organisation
+import uk.gov.hmrc.emcstfefrontend.config.EnrolmentKeys
+import uk.gov.hmrc.emcstfefrontend.fixtures.BaseFixtures
+import uk.gov.hmrc.emcstfefrontend.support.WireMockMethods
+
+import scala.xml.Elem
+
+object AuthStub extends DownstreamStub with BaseFixtures {
+
+  val authoriseUri = "/auth/authorise"
+
+  def authorised(exciseNumber: String = ern): StubMapping =
+    onSuccess(POST, authoriseUri, OK, Json.obj(
+        "affinityGroup" -> "Organisation",
+        "allEnrolments" -> Json.arr(
+          Json.obj(
+            "key" -> EnrolmentKeys.EMCS_ENROLMENT,
+            "identifiers" -> Json.arr(
+              Json.obj(
+                "key" -> EnrolmentKeys.ERN,
+                "value" -> exciseNumber,
+                "state" -> EnrolmentKeys.ACTIVATED
+              )
+            )
+          )
+        ),
+        "internalId" -> testInternalId,
+        "optionalCredentials" -> Json.obj(
+          "providerId" -> testCredId,
+          "providerType" -> "gg"
+        )
+      ))
+
+  def unauthorised(): StubMapping =
+    onError(POST, authoriseUri, UNAUTHORIZED)
+}

--- a/it/uk/gov/hmrc/emcstfefrontend/stubs/AuthStub.scala
+++ b/it/uk/gov/hmrc/emcstfefrontend/stubs/AuthStub.scala
@@ -18,14 +18,9 @@ package uk.gov.hmrc.emcstfefrontend.stubs
 
 import com.github.tomakehurst.wiremock.stubbing.StubMapping
 import play.api.http.Status.{OK, UNAUTHORIZED}
-import play.api.libs.json.{JsValue, Json}
-import uk.gov.hmrc.auth.core.AffinityGroup
-import uk.gov.hmrc.auth.core.AffinityGroup.Organisation
+import play.api.libs.json.Json
 import uk.gov.hmrc.emcstfefrontend.config.EnrolmentKeys
 import uk.gov.hmrc.emcstfefrontend.fixtures.BaseFixtures
-import uk.gov.hmrc.emcstfefrontend.support.WireMockMethods
-
-import scala.xml.Elem
 
 object AuthStub extends DownstreamStub with BaseFixtures {
 

--- a/it/uk/gov/hmrc/emcstfefrontend/stubs/DownstreamStub.scala
+++ b/it/uk/gov/hmrc/emcstfefrontend/stubs/DownstreamStub.scala
@@ -22,7 +22,7 @@ import uk.gov.hmrc.emcstfefrontend.support.WireMockMethods
 
 import scala.xml.Elem
 
-object DownstreamStub extends WireMockMethods {
+trait DownstreamStub extends WireMockMethods {
 
   def onSuccess(method: HTTPMethod, uri: String, status: Int, body: JsValue): StubMapping = {
     when(method = method, uri = uri)
@@ -39,6 +39,9 @@ object DownstreamStub extends WireMockMethods {
       .thenReturn(status = status, body)
   }
 
+  def onError(method: HTTPMethod, uri: String, errorStatus: Int): StubMapping =
+    when(method, uri).thenReturn(errorStatus)
+
   def onError(method: HTTPMethod, uri: String, errorStatus: Int, errorBody: String): StubMapping = {
     when(method = method, uri = uri)
       .thenReturn(status = errorStatus, errorBody)
@@ -49,3 +52,4 @@ object DownstreamStub extends WireMockMethods {
       .thenReturn(status = errorStatus, errorBody)
   }
 }
+object DownstreamStub extends DownstreamStub

--- a/it/uk/gov/hmrc/emcstfefrontend/support/IntegrationBaseSpec.scala
+++ b/it/uk/gov/hmrc/emcstfefrontend/support/IntegrationBaseSpec.scala
@@ -18,26 +18,22 @@ package uk.gov.hmrc.emcstfefrontend.support
 
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
+import play.api.http.HeaderNames
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json.{JsValue, Json}
 import play.api.libs.ws.{WSClient, WSRequest, WSResponse}
 import play.api.{Application, Environment, Mode}
 
-trait IntegrationBaseSpec extends UnitSpec with WireMockHelper with GuiceOneServerPerSuite
+trait IntegrationBaseSpec extends SessionCookieBaker with UnitSpec with WireMockHelper with GuiceOneServerPerSuite
   with BeforeAndAfterEach with BeforeAndAfterAll {
-
-  val mockHost: String = WireMockHelper.host
-  val mockPort: String = WireMockHelper.wireMockPort.toString
 
   lazy val client: WSClient = app.injector.instanceOf[WSClient]
 
-  def servicesConfig: Map[String, String] = Map(
-    "microservice.services.reference-data.host" -> mockHost,
-    "microservice.services.reference-data.port" -> mockPort,
-    "microservice.services.emcs-tfe.host" -> mockHost,
-    "microservice.services.emcs-tfe.port" -> mockPort,
-    "auditing.consumer.baseUri.host" -> mockHost,
-    "auditing.consumer.baseUri.port" -> mockPort,
+  def servicesConfig: Map[String, _] = Map(
+    "microservice.services.auth.port" -> WireMockHelper.wireMockPort,
+    "microservice.services.reference-data.port" -> WireMockHelper.wireMockPort,
+    "microservice.services.emcs-tfe.port" -> WireMockHelper.wireMockPort,
+    "auditing.consumer.baseUri.port" -> WireMockHelper.wireMockPort,
     "feature-switch.enable-reference-data-stub-source" -> "true"
   )
 
@@ -56,7 +52,10 @@ trait IntegrationBaseSpec extends UnitSpec with WireMockHelper with GuiceOneServ
     super.afterAll()
   }
 
-  def buildRequest(path: String): WSRequest = client.url(s"http://localhost:$port/emcs-tfe$path").withFollowRedirects(false)
+  def buildRequest(path: String, additionalCookieData: Map[String, String] = Map()): WSRequest = client
+    .url(s"http://localhost:$port/emcs-tfe$path")
+    .withHttpHeaders(HeaderNames.COOKIE -> bakeSessionCookie(additionalCookieData))
+    .withFollowRedirects(false)
 
   def document(response: WSResponse): JsValue = Json.parse(response.body)
 }

--- a/it/uk/gov/hmrc/emcstfefrontend/support/SessionCookieBaker.scala
+++ b/it/uk/gov/hmrc/emcstfefrontend/support/SessionCookieBaker.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.emcstfefrontend.support
+
+import play.api.Application
+import play.api.libs.crypto.CookieSigner
+import uk.gov.hmrc.crypto.{CompositeSymmetricCrypto, PlainText, SymmetricCryptoFactory}
+import uk.gov.hmrc.http.SessionKeys
+
+import java.net.URLEncoder
+import java.util.UUID
+
+trait SessionCookieBaker { _: IntegrationBaseSpec =>
+  private val cookieKey = "gvBoGdgzqG1AarzF1LY0zQ=="
+  val sessionId = s"stubbed-${UUID.randomUUID}"
+
+  private def cookieValue(sessionData: Map[String, String]) = {
+    def encode(data: Map[String, String]): PlainText = {
+      val encoded = data.map {
+        case (k, v) => URLEncoder.encode(k, "UTF-8") + "=" + URLEncoder.encode(v, "UTF-8")
+      }.mkString("&")
+      val key = "yNhI04vHs9<_HWbC`]20u`37=NGLGYY5:0Tg5?y`W<NoJnXWqmjcgZBec@rOxb^G".getBytes
+
+      val cookieSignerCache: Application => CookieSigner = Application.instanceCache[CookieSigner]
+      def cookieSigner: CookieSigner = cookieSignerCache(app)
+
+      PlainText(cookieSigner.sign(encoded, key) + "-" + encoded)
+    }
+
+    val encodedCookie = encode(sessionData)
+    val encrypted = SymmetricCryptoFactory.aesGcmCrypto(cookieKey).encrypt(encodedCookie).value
+
+    s"""mdtp="$encrypted"; Path=/; HTTPOnly"; Path=/; HTTPOnly"""
+  }
+
+  private def cookieData(additionalData: Map[String, String]): Map[String, String] =
+    Map(
+      SessionKeys.sessionId -> sessionId,
+      SessionKeys.authToken -> "token",
+      SessionKeys.authToken -> "auth"
+    ) ++ additionalData
+
+  def bakeSessionCookie(additionalData: Map[String, String] = Map()): String =
+    cookieValue(cookieData(additionalData))
+}

--- a/it/uk/gov/hmrc/emcstfefrontend/support/SessionCookieBaker.scala
+++ b/it/uk/gov/hmrc/emcstfefrontend/support/SessionCookieBaker.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.emcstfefrontend.support
 
 import play.api.Application
 import play.api.libs.crypto.CookieSigner
-import uk.gov.hmrc.crypto.{CompositeSymmetricCrypto, PlainText, SymmetricCryptoFactory}
+import uk.gov.hmrc.crypto.{PlainText, SymmetricCryptoFactory}
 import uk.gov.hmrc.http.SessionKeys
 
 import java.net.URLEncoder

--- a/test/uk/gov/hmrc/emcstfefrontend/controllers/ModeOfTransportControllerSpec.scala
+++ b/test/uk/gov/hmrc/emcstfefrontend/controllers/ModeOfTransportControllerSpec.scala
@@ -21,6 +21,7 @@ import play.api.mvc.{AnyContentAsEmpty, MessagesControllerComponents}
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import uk.gov.hmrc.emcstfefrontend.config.ErrorHandler
+import uk.gov.hmrc.emcstfefrontend.controllers.predicates.FakeAuthAction
 import uk.gov.hmrc.emcstfefrontend.fixtures.ModeOfTransportListFixture
 import uk.gov.hmrc.emcstfefrontend.mocks.services.MockModeOfTransportService
 import uk.gov.hmrc.emcstfefrontend.models.response.UnexpectedDownstreamResponseError
@@ -30,7 +31,7 @@ import uk.gov.hmrc.http.HeaderCarrier
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class ModeOfTransportControllerSpec extends UnitSpec with ModeOfTransportListFixture {
+class ModeOfTransportControllerSpec extends UnitSpec with ModeOfTransportListFixture with FakeAuthAction {
 
   trait Test extends MockModeOfTransportService {
     implicit val hc: HeaderCarrier = HeaderCarrier()
@@ -39,11 +40,11 @@ class ModeOfTransportControllerSpec extends UnitSpec with ModeOfTransportListFix
     implicit val postRequest: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("POST", "/")
 
     val controller: ModeOfTransportController = new ModeOfTransportController(
-      app.injector.instanceOf[MessagesControllerComponents],
-      mockService,
-      app.injector.instanceOf[ModeOfTransportPage],
-      app.injector.instanceOf[ErrorHandler],
-      ec
+      mcc = app.injector.instanceOf[MessagesControllerComponents],
+      service = mockService,
+      modeOfTransportPage = app.injector.instanceOf[ModeOfTransportPage],
+      errorHandler = app.injector.instanceOf[ErrorHandler],
+      authAction = FakeSuccessAuthAction
     )
   }
 

--- a/test/uk/gov/hmrc/emcstfefrontend/controllers/ViewMovementControllerSpec.scala
+++ b/test/uk/gov/hmrc/emcstfefrontend/controllers/ViewMovementControllerSpec.scala
@@ -51,8 +51,7 @@ class ViewMovementControllerSpec extends UnitSpec with FakeAuthAction {
   "GET /consignment/:exciseRegistrationNumber/:arc" should {
     "return 200" when {
       "connector call is successful" in new Test {
-        val ern = "ERN"
-        val arc = "ARC"
+
         val model: GetMovementResponse = GetMovementResponse("", "", "", LocalDate.parse("2008-11-20"), "", 0)
 
         MockEmcsTfeConnector
@@ -66,8 +65,6 @@ class ViewMovementControllerSpec extends UnitSpec with FakeAuthAction {
     }
     "return 500" when {
       "connector call is unsuccessful" in new Test {
-        val ern = "ERN"
-        val arc = "ARC"
 
         MockEmcsTfeConnector
           .getMovement()

--- a/test/uk/gov/hmrc/emcstfefrontend/controllers/ViewMovementControllerSpec.scala
+++ b/test/uk/gov/hmrc/emcstfefrontend/controllers/ViewMovementControllerSpec.scala
@@ -21,6 +21,7 @@ import play.api.mvc.{AnyContentAsEmpty, MessagesControllerComponents, Result}
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import uk.gov.hmrc.emcstfefrontend.config.ErrorHandler
+import uk.gov.hmrc.emcstfefrontend.controllers.predicates.FakeAuthAction
 import uk.gov.hmrc.emcstfefrontend.mocks.connectors.MockEmcsTfeConnector
 import uk.gov.hmrc.emcstfefrontend.models.response.UnexpectedDownstreamResponseError
 import uk.gov.hmrc.emcstfefrontend.models.response.emcsTfe.GetMovementResponse
@@ -31,7 +32,7 @@ import uk.gov.hmrc.http.HeaderCarrier
 import java.time.LocalDate
 import scala.concurrent.{ExecutionContext, Future}
 
-class ViewMovementControllerSpec extends UnitSpec {
+class ViewMovementControllerSpec extends UnitSpec with FakeAuthAction {
 
   trait Test extends MockEmcsTfeConnector {
     implicit val hc: HeaderCarrier = HeaderCarrier()
@@ -43,7 +44,7 @@ class ViewMovementControllerSpec extends UnitSpec {
       mockGetMovementConnector,
       app.injector.instanceOf[ViewMovementPage],
       app.injector.instanceOf[ErrorHandler],
-      ec
+      FakeSuccessAuthAction
     )
   }
 

--- a/test/uk/gov/hmrc/emcstfefrontend/controllers/ViewMovementListControllerSpec.scala
+++ b/test/uk/gov/hmrc/emcstfefrontend/controllers/ViewMovementListControllerSpec.scala
@@ -23,6 +23,7 @@ import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import play.twirl.api.Html
 import uk.gov.hmrc.emcstfefrontend.config.ErrorHandler
+import uk.gov.hmrc.emcstfefrontend.controllers.predicates.FakeAuthAction
 import uk.gov.hmrc.emcstfefrontend.fixtures.MovementListFixtures
 import uk.gov.hmrc.emcstfefrontend.fixtures.messages.EN
 import uk.gov.hmrc.emcstfefrontend.mocks.connectors.MockEmcsTfeConnector
@@ -33,7 +34,7 @@ import uk.gov.hmrc.http.HeaderCarrier
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class ViewMovementListControllerSpec extends UnitSpec with MovementListFixtures {
+class ViewMovementListControllerSpec extends UnitSpec with MovementListFixtures with FakeAuthAction {
 
   trait Test extends MockEmcsTfeConnector {
     implicit val hc: HeaderCarrier = HeaderCarrier()
@@ -49,7 +50,7 @@ class ViewMovementListControllerSpec extends UnitSpec with MovementListFixtures 
       mockGetMovementListConnector,
       view,
       errorHandler,
-      ec
+      FakeSuccessAuthAction
     )
   }
 

--- a/test/uk/gov/hmrc/emcstfefrontend/controllers/errors/UnauthorisedControllerSpec.scala
+++ b/test/uk/gov/hmrc/emcstfefrontend/controllers/errors/UnauthorisedControllerSpec.scala
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.emcstfefrontend.controllers.errors
+
+import play.api.mvc.{AnyContentAsEmpty, MessagesControllerComponents}
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import play.twirl.api.Html
+import uk.gov.hmrc.emcstfefrontend.config.ErrorHandler
+import uk.gov.hmrc.emcstfefrontend.fixtures.messages.UnauthorisedMessages
+import uk.gov.hmrc.emcstfefrontend.mocks.services.MockHelloWorldService
+import uk.gov.hmrc.emcstfefrontend.support.UnitSpec
+import uk.gov.hmrc.http.HeaderCarrier
+
+import scala.concurrent.ExecutionContext
+
+class UnauthorisedControllerSpec extends UnitSpec with MockHelloWorldService {
+
+  trait Test {
+    implicit val hc: HeaderCarrier = HeaderCarrier()
+    implicit val ec: ExecutionContext = app.injector.instanceOf[ExecutionContext]
+    implicit val fakeRequest: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("GET", "/")
+
+    val errorHandler = app.injector.instanceOf[ErrorHandler]
+
+    val controller: UnauthorisedController = new UnauthorisedController(
+      app.injector.instanceOf[MessagesControllerComponents],
+      errorHandler,
+      ec
+    )
+  }
+
+  "GET /error/unauthorised" when {
+
+    Seq(UnauthorisedMessages.English, UnauthorisedMessages.Welsh) foreach { viewMessages =>
+
+      s"being rendered for lang '${viewMessages.lang.code}'" must {
+
+        s"return UNAUTHORIZED ($UNAUTHORIZED) and correct Error Messages" in new Test {
+
+          val result = controller.unauthorised()(fakeRequest)
+
+          status(result) shouldBe UNAUTHORIZED
+          Html(contentAsString(result)) shouldBe errorHandler.standardErrorTemplate(
+            pageTitle = viewMessages.title,
+            heading = viewMessages.heading,
+            message = viewMessages.message
+          )
+        }
+      }
+    }
+  }
+}

--- a/test/uk/gov/hmrc/emcstfefrontend/controllers/predicates/AuthActionSpec.scala
+++ b/test/uk/gov/hmrc/emcstfefrontend/controllers/predicates/AuthActionSpec.scala
@@ -1,0 +1,214 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.emcstfefrontend.controllers.predicates
+
+import com.google.inject.Inject
+import play.api.mvc.{Action, AnyContent, BodyParsers, Results}
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import uk.gov.hmrc.auth.core.AffinityGroup.{Agent, Organisation}
+import uk.gov.hmrc.auth.core._
+import uk.gov.hmrc.auth.core.authorise.Predicate
+import uk.gov.hmrc.auth.core.retrieve.{Credentials, Retrieval, ~}
+import uk.gov.hmrc.emcstfefrontend.config.{AppConfig, EnrolmentKeys}
+import uk.gov.hmrc.emcstfefrontend.controllers
+import uk.gov.hmrc.emcstfefrontend.fixtures.BaseFixtures
+import uk.gov.hmrc.emcstfefrontend.support.UnitSpec
+import uk.gov.hmrc.http.HeaderCarrier
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class AuthActionSpec extends UnitSpec with BaseFixtures {
+
+  lazy val bodyParsers = app.injector.instanceOf[BodyParsers.Default]
+  lazy val appConfig = app.injector.instanceOf[AppConfig]
+  implicit lazy val ec = app.injector.instanceOf[ExecutionContext]
+
+  type AuthRetrieval = ~[~[~[Option[AffinityGroup], Enrolments], Option[String]], Option[Credentials]]
+
+  implicit val fakeRequest = FakeRequest()
+
+  trait Harness {
+
+    val authConnector: AuthConnector
+    lazy val authAction = new AuthenticatedUserAction(authConnector, appConfig, bodyParsers)
+    def onPageLoad(): Action[AnyContent] = authAction { _ => Results.Ok }
+
+    lazy val result = onPageLoad()(fakeRequest)
+  }
+
+  def authResponse(affinityGroup: Option[AffinityGroup] = Some(Organisation),
+                   enrolments: Enrolments = Enrolments(Set.empty),
+                   internalId: Option[String] = Some(testInternalId),
+                   credId: Option[Credentials] = Some(Credentials(testCredId, "gg"))): AuthRetrieval =
+    new ~(new ~(new ~(affinityGroup, enrolments), internalId), credId)
+
+  "AuthAction" when {
+
+    "User is not logged in" must {
+
+      "redirect to the sign-in URL with the ContinueURL set" in new Harness {
+
+        override val authConnector = new FakeFailingAuthConnector(new BearerTokenExpired)
+
+        status(result) shouldBe SEE_OTHER
+        redirectLocation(result) shouldBe Some("http://localhost:9949/auth-login-stub/gg-sign-in?continue=http%3A%2F%2Flocalhost%3A8310%2Femcs-tfe")
+      }
+    }
+
+    "An unexpected Authorisation exception is returned from the Auth library" must {
+
+      "redirect to unauthorised" in new Harness {
+
+        override val authConnector = new FakeFailingAuthConnector(new InsufficientConfidenceLevel)
+
+        status(result) shouldBe SEE_OTHER
+        redirectLocation(result) shouldBe Some(controllers.errors.routes.UnauthorisedController.unauthorised().url)
+      }
+    }
+
+    "User is logged in" when {
+
+      "Affinity Group of user does not exist" must {
+
+        "redirect to unauthorised" in new Harness {
+
+          override val authConnector = new FakeSuccessAuthConnector(authResponse(affinityGroup = None))
+
+          status(result) shouldBe SEE_OTHER
+          redirectLocation(result) shouldBe Some(controllers.errors.routes.UnauthorisedController.unauthorised().url)
+        }
+      }
+
+      "Affinity Group of user is not Organisation" must {
+
+        "redirect to unauthorised" in new Harness {
+
+          override val authConnector = new FakeSuccessAuthConnector(authResponse(affinityGroup = Some(Agent)))
+
+          status(result) shouldBe SEE_OTHER
+          redirectLocation(result) shouldBe Some(controllers.errors.routes.UnauthorisedController.unauthorised().url)
+        }
+      }
+
+      "Affinity Group of user is Organisation" when {
+
+        "internalId is not retrieved from Auth" must {
+
+          "redirect to unauthorised" in new Harness {
+
+            override val authConnector = new FakeSuccessAuthConnector(authResponse(internalId = None))
+
+            status(result) shouldBe SEE_OTHER
+            redirectLocation(result) shouldBe Some(controllers.errors.routes.UnauthorisedController.unauthorised().url)
+          }
+        }
+
+        "internalId is retrieved from Auth" when {
+
+          "credential is not retrieved from Auth" must {
+
+            "redirect to unauthorised" in new Harness {
+
+              override val authConnector = new FakeSuccessAuthConnector(authResponse(credId = None))
+
+              status(result) shouldBe SEE_OTHER
+              redirectLocation(result) shouldBe Some(controllers.errors.routes.UnauthorisedController.unauthorised().url)
+            }
+          }
+
+          "credential is retrieved from Auth" when {
+
+            s"Enrolments is missing the ${EnrolmentKeys.EMCS_ENROLMENT}" must {
+
+              "redirect to unauthorised" in new Harness {
+
+                override val authConnector = new FakeSuccessAuthConnector(authResponse())
+
+                status(result) shouldBe SEE_OTHER
+                redirectLocation(result) shouldBe Some(controllers.errors.routes.UnauthorisedController.unauthorised().url)
+              }
+            }
+
+            s"Enrolments exists for ${EnrolmentKeys.EMCS_ENROLMENT} but is NOT activated" must {
+
+              "redirect to unauthorised" in new Harness {
+
+                override val authConnector = new FakeSuccessAuthConnector(authResponse(enrolments = Enrolments(Set(
+                  Enrolment(
+                    key = EnrolmentKeys.EMCS_ENROLMENT,
+                    identifiers = Seq(EnrolmentIdentifier(EnrolmentKeys.ERN, ern)),
+                    state = EnrolmentKeys.INACTIVE
+                  )
+                ))))
+
+                status(result) shouldBe SEE_OTHER
+                redirectLocation(result) shouldBe Some(controllers.errors.routes.UnauthorisedController.unauthorised().url)
+              }
+            }
+
+            s"Enrolments exists for ${EnrolmentKeys.EMCS_ENROLMENT} AND is activated" when {
+
+              s"the ${EnrolmentKeys.ERN} identifier is missing (should be impossible)" must {
+
+                "redirect to unauthorised" in new Harness {
+
+                  override val authConnector = new FakeSuccessAuthConnector(authResponse(enrolments = Enrolments(Set(
+                    Enrolment(
+                      key = EnrolmentKeys.EMCS_ENROLMENT,
+                      identifiers = Seq(),
+                      state = EnrolmentKeys.ACTIVATED
+                    )
+                  ))))
+
+                  status(result) shouldBe SEE_OTHER
+                  redirectLocation(result) shouldBe Some(controllers.errors.routes.UnauthorisedController.unauthorised().url)
+                }
+              }
+
+              s"the ${EnrolmentKeys.ERN} identifier is present" must {
+
+                "allow the User through, returning a 200 (OK)" in new Harness {
+
+                  override val authConnector = new FakeSuccessAuthConnector(authResponse(enrolments = Enrolments(Set(
+                    Enrolment(
+                      key = EnrolmentKeys.EMCS_ENROLMENT,
+                      identifiers = Seq(EnrolmentIdentifier(EnrolmentKeys.ERN, ern)),
+                      state = EnrolmentKeys.ACTIVATED
+                    )
+                  ))))
+
+                  status(result) shouldBe OK
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+class FakeSuccessAuthConnector[B] @Inject()(response: B) extends AuthConnector {
+  override def authorise[A](predicate: Predicate, retrieval: Retrieval[A])(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[A] =
+    Future.successful(response.asInstanceOf[A])
+}
+
+class FakeFailingAuthConnector @Inject()(exceptionToReturn: Throwable) extends AuthConnector {
+  override def authorise[A](predicate: Predicate, retrieval: Retrieval[A])(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[A] =
+    Future.failed(exceptionToReturn)
+}

--- a/test/uk/gov/hmrc/emcstfefrontend/controllers/predicates/AuthActionSpec.scala
+++ b/test/uk/gov/hmrc/emcstfefrontend/controllers/predicates/AuthActionSpec.scala
@@ -17,6 +17,7 @@
 package uk.gov.hmrc.emcstfefrontend.controllers.predicates
 
 import com.google.inject.Inject
+import play.api.i18n.MessagesApi
 import play.api.mvc.{Action, AnyContent, BodyParsers, Results}
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
@@ -37,6 +38,7 @@ class AuthActionSpec extends UnitSpec with BaseFixtures {
   lazy val bodyParsers = app.injector.instanceOf[BodyParsers.Default]
   lazy val appConfig = app.injector.instanceOf[AppConfig]
   implicit lazy val ec = app.injector.instanceOf[ExecutionContext]
+  implicit lazy val messagesApi = app.injector.instanceOf[MessagesApi]
 
   type AuthRetrieval = ~[~[~[Option[AffinityGroup], Enrolments], Option[String]], Option[Credentials]]
 
@@ -45,7 +47,7 @@ class AuthActionSpec extends UnitSpec with BaseFixtures {
   trait Harness {
 
     val authConnector: AuthConnector
-    lazy val authAction = new AuthenticatedUserAction(authConnector, appConfig, bodyParsers)
+    lazy val authAction = new AuthActionImpl(authConnector, appConfig, bodyParsers)
     def onPageLoad(): Action[AnyContent] = authAction { _ => Results.Ok }
 
     lazy val result = onPageLoad()(fakeRequest)

--- a/test/uk/gov/hmrc/emcstfefrontend/controllers/predicates/FakeAuthAction.scala
+++ b/test/uk/gov/hmrc/emcstfefrontend/controllers/predicates/FakeAuthAction.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.emcstfefrontend.controllers.predicates
+
+import play.api.i18n.MessagesApi
+import play.api.mvc._
+import play.api.test.StubBodyParserFactory
+import uk.gov.hmrc.emcstfefrontend.fixtures.BaseFixtures
+import uk.gov.hmrc.emcstfefrontend.models.auth.UserRequest
+import uk.gov.hmrc.emcstfefrontend.support.UnitSpec
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait FakeAuthAction extends StubBodyParserFactory with BaseFixtures { _: UnitSpec =>
+
+  implicit lazy val messagesApi = app.injector.instanceOf[MessagesApi]
+  implicit lazy val ec = app.injector.instanceOf[ExecutionContext]
+
+  object FakeSuccessAuthAction extends AuthAction {
+
+    override implicit protected def executionContext: ExecutionContext = ec
+
+    override def parser: BodyParser[AnyContent] = stubBodyParser()
+
+    override def invokeBlock[A](request: Request[A], block: UserRequest[A] => Future[Result]): Future[Result] =
+      block(UserRequest(request, ern, testInternalId, testCredId))
+  }
+}

--- a/test/uk/gov/hmrc/emcstfefrontend/fixtures/BaseFixtures.scala
+++ b/test/uk/gov/hmrc/emcstfefrontend/fixtures/BaseFixtures.scala
@@ -18,7 +18,8 @@ package uk.gov.hmrc.emcstfefrontend.fixtures
 
 trait BaseFixtures {
 
-  val ern = "SomeErn"
+  val ern = "ERN"
+  val arc = "ARC"
   val testCredId = "cred1234567891"
   val testInternalId = "int1234567891"
 

--- a/test/uk/gov/hmrc/emcstfefrontend/fixtures/ModeOfTransportListFixture.scala
+++ b/test/uk/gov/hmrc/emcstfefrontend/fixtures/ModeOfTransportListFixture.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.emcstfefrontend.fixtures
 import play.api.libs.json.{JsValue, Json}
 import uk.gov.hmrc.emcstfefrontend.models.response.referenceData.{ModeOfTransportListModel, ModeOfTransportModel}
 
-trait ModeOfTransportListFixture {
+trait ModeOfTransportListFixture extends BaseFixtures {
 
   val validModeOfTransportJson: JsValue = Json.parse(
     """

--- a/test/uk/gov/hmrc/emcstfefrontend/fixtures/MovementListFixtures.scala
+++ b/test/uk/gov/hmrc/emcstfefrontend/fixtures/MovementListFixtures.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.emcstfefrontend.fixtures
 import play.api.libs.json.{JsValue, Json}
 import uk.gov.hmrc.emcstfefrontend.models.response.emcsTfe.{GetMovementListItem, GetMovementListResponse}
 
-import java.time.{Instant, LocalDateTime}
+import java.time.LocalDateTime
 
 trait MovementListFixtures extends BaseFixtures {
 

--- a/test/uk/gov/hmrc/emcstfefrontend/fixtures/messages/UnauthorisedMessages.scala
+++ b/test/uk/gov/hmrc/emcstfefrontend/fixtures/messages/UnauthorisedMessages.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.emcstfefrontend.fixtures.messages
+
+object UnauthorisedMessages {
+
+  sealed trait ViewMessages { _: i18n =>
+    val title: String
+    val heading: String
+    val message: String
+  }
+
+  object English extends ViewMessages with EN {
+    override val title: String = "Unauthorised"
+    override val heading: String = "Unauthorised"
+    override val message: String = "You are not authorised to access this service"
+  }
+
+  object Welsh extends ViewMessages with CY {
+    override val title: String = "Unauthorised"
+    override val heading: String = "Unauthorised"
+    override val message: String = "You are not authorised to access this service"
+  }
+}

--- a/test/uk/gov/hmrc/emcstfefrontend/mocks/config/MockAppConfig.scala
+++ b/test/uk/gov/hmrc/emcstfefrontend/mocks/config/MockAppConfig.scala
@@ -25,8 +25,8 @@ trait MockAppConfig extends MockFactory {
 
   object MockedAppConfig {
     // MTD ID Lookup Config
-    def referenceDataBaseUrl: CallHandler[String] = (mockAppConfig.referenceDataBaseUrl _: () => String).expects()
-    def emcsTfeBaseUrl: CallHandler[String] = (mockAppConfig.emcsTfeBaseUrl _: () => String).expects()
+    def referenceDataBaseUrl: CallHandler[String] = (() => mockAppConfig.referenceDataBaseUrl).expects()
+    def emcsTfeBaseUrl: CallHandler[String] = (() => mockAppConfig.emcsTfeBaseUrl).expects()
     def getReferenceDataStubFeatureSwitch: CallHandler[Boolean] = (mockAppConfig.getReferenceDataStubFeatureSwitch _: () => Boolean).expects()
   }
 

--- a/test/uk/gov/hmrc/emcstfefrontend/utils/LoggingSpec.scala
+++ b/test/uk/gov/hmrc/emcstfefrontend/utils/LoggingSpec.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.emcstfefrontend.utils
+
+import ch.qos.logback.classic.Level
+import org.scalatestplus.play.PlaySpec
+import uk.gov.hmrc.play.bootstrap.tools.LogCapturing
+
+class LoggingSpec extends PlaySpec with LogCapturing {
+
+  val ex = new Exception("foobar")
+
+  object TestLogging extends Logging
+
+  "have the logger configured correctly" in {
+    TestLogging.logger.logger.getName mustBe s"uk.gov.hmrc.emcstfefrontend.utils.LoggingSpec$$TestLogging"
+  }
+
+  "when logging" must {
+
+    Seq(None, Some(new Exception("fooBar"))) foreach { optEx =>
+
+      withCaptureOfLoggingFrom(TestLogging.logger) { logs =>
+        Seq(
+          logMsg(Level.DEBUG, optEx),
+          logMsg(Level.INFO, optEx),
+          logMsg(Level.WARN, optEx),
+          logMsg(Level.ERROR, optEx)
+        ) foreach { level =>
+
+          s"at level $level" + optEx.fold("")(s" with exception of " + _) must {
+
+            s"output the correct message and level (prefixing with the class/object name)" in {
+
+              logs.find(_.getLevel == level) match {
+                case Some(value) => value.getMessage mustBe s"[TestLogging] $level Message"
+                case None => fail(s"Could not find $level message")
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  private def logMsg(level: Level, ex: Option[Exception]): Level = {
+    import TestLogging.logger
+    val msg = s"$level Message"
+    level match {
+      case Level.DEBUG => ex.fold(logger.debug(msg))(logger.debug(msg, _))
+      case Level.INFO =>  ex.fold(logger.info(msg))(logger.info(msg, _))
+      case Level.WARN =>  ex.fold(logger.warn(msg))(logger.warn(msg, _))
+      case _ =>           ex.fold(logger.error(msg))(logger.error(msg, _))
+    }
+    level
+  }
+}


### PR DESCRIPTION
**Notes**:

- Add Auth predicate that can be used as the `action` for Controllers to be guarded by Auth
- Retrieve the ERN from the Enrolment 
- Update `Logging` util to provide more consistency for log output going forward

**Dependent PRs**:
- App-Config-Base PR (merge before this PR): https://github.com/hmrc/app-config-base/pull/8095
- Service-Manager-Config PR: https://github.com/hmrc/service-manager-config/pull/4957
- Build-Jobs PR: https://github.com/hmrc/build-jobs/pull/12729
- Service-Manager PR: https://github.com/hmrc/service-manager-config/pull/4972
- Performance-Tests PR: https://github.com/hmrc/emcs-tfe-performance-tests/pull/5
- ⚠️ Will require changes to Journey Tests