### PR TITLE
[ETFE-577] Add IndexController that will list ERNs when more than one Enrolment is present

### DIFF
--- a/app/uk/gov/hmrc/emcstfefrontend/config/Module.scala
+++ b/app/uk/gov/hmrc/emcstfefrontend/config/Module.scala
@@ -17,12 +17,13 @@
 package uk.gov.hmrc.emcstfefrontend.config
 
 import com.google.inject.AbstractModule
-import uk.gov.hmrc.emcstfefrontend.controllers.predicates.{AuthAction, AuthActionImpl}
+import uk.gov.hmrc.emcstfefrontend.controllers.predicates.{AuthAction, AuthActionImpl, SelectExciseNumberAuthAction, SelectExciseNumberAuthActionImpl}
 
 class Module extends AbstractModule {
 
   override def configure(): Unit = {
     bind(classOf[AppConfig]).asEagerSingleton()
     bind(classOf[AuthAction]).to(classOf[AuthActionImpl])
+    bind(classOf[SelectExciseNumberAuthAction]).to(classOf[SelectExciseNumberAuthActionImpl])
   }
 }

--- a/app/uk/gov/hmrc/emcstfefrontend/controllers/IndexController.scala
+++ b/app/uk/gov/hmrc/emcstfefrontend/controllers/IndexController.scala
@@ -17,10 +17,10 @@
 package uk.gov.hmrc.emcstfefrontend.controllers
 
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import uk.gov.hmrc.emcstfefrontend.config.ErrorHandler
-import uk.gov.hmrc.emcstfefrontend.connectors.emcsTfe.GetMovementConnector
-import uk.gov.hmrc.emcstfefrontend.controllers.predicates.AuthAction
-import uk.gov.hmrc.emcstfefrontend.views.html.ViewMovementPage
+import uk.gov.hmrc.emcstfefrontend.config.EnrolmentKeys
+import uk.gov.hmrc.emcstfefrontend.controllers.predicates.SelectExciseNumberAuthAction
+import uk.gov.hmrc.emcstfefrontend.utils.Logging
+import uk.gov.hmrc.emcstfefrontend.views.html.ExciseNumbersPage
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
 import javax.inject.{Inject, Singleton}
@@ -28,22 +28,21 @@ import scala.concurrent.ExecutionContext
 
 @Singleton
 class IndexController @Inject()(mcc: MessagesControllerComponents,
-                                connector: GetMovementConnector,
-                                viewMovementPage: ViewMovementPage,
-                                errorHandler: ErrorHandler,
-                                authAction: AuthAction
-                                      )(implicit val executionContext: ExecutionContext) extends FrontendController(mcc) {
+                                view: ExciseNumbersPage,
+                                authAction: SelectExciseNumberAuthAction
+                               )(implicit val executionContext: ExecutionContext) extends FrontendController(mcc) with Logging {
 
-  def exciseNumber(): Action[AnyContent] = Action {
-    NotImplemented
+  def exciseNumber(): Action[AnyContent] = authAction { implicit request =>
+    request.exciseEnrolments.flatMap(_.identifiers.find(_.key == EnrolmentKeys.ERN)) match {
+      case exciseRegistrationNumbers if exciseRegistrationNumbers.isEmpty =>
+        logger.error("[exciseNumber] User had no ERN identifiers against their EMCS enrolment(s)")
+        Redirect(errors.routes.UnauthorisedController.unauthorised().url)
+      case exciseRegistrationNumbers if exciseRegistrationNumbers.size == 1 =>
+        logger.debug("[exciseNumber] User only has one active EMCS enrolment.")
+        Redirect(routes.ViewMovementListController.viewMovementList(exciseRegistrationNumbers.head.value))
+      case exciseRegistrationNumbers =>
+        logger.debug("[exciseNumber] User has multiple active EMCS enrolments.")
+        Ok(view(exciseRegistrationNumbers.map(_.value)))
+    }
   }
-
-//  def exiseNumber(): Action[AnyContent] = authAction.async { implicit request =>
-//    authAction.checkErnMatchesRequest(exciseRegistrationNumber) {
-//      connector.getMovement(exciseRegistrationNumber, arc).map {
-//        case Right(response) => Ok(viewMovementPage(exciseRegistrationNumber, arc, response))
-//        case Left(_) => InternalServerError(errorHandler.standardErrorTemplate())
-//      }
-//    }
-//  }
 }

--- a/app/uk/gov/hmrc/emcstfefrontend/controllers/IndexController.scala
+++ b/app/uk/gov/hmrc/emcstfefrontend/controllers/IndexController.scala
@@ -27,18 +27,23 @@ import javax.inject.{Inject, Singleton}
 import scala.concurrent.ExecutionContext
 
 @Singleton
-class ViewMovementController @Inject()(mcc: MessagesControllerComponents,
-                                       connector: GetMovementConnector,
-                                       viewMovementPage: ViewMovementPage,
-                                       errorHandler: ErrorHandler,
-                                       authAction: AuthAction
+class IndexController @Inject()(mcc: MessagesControllerComponents,
+                                connector: GetMovementConnector,
+                                viewMovementPage: ViewMovementPage,
+                                errorHandler: ErrorHandler,
+                                authAction: AuthAction
                                       )(implicit val executionContext: ExecutionContext) extends FrontendController(mcc) {
 
-  def viewMovement(exciseRegistrationNumber: String, arc: String): Action[AnyContent] =
-    authAction(exciseRegistrationNumber).async { implicit request =>
-      connector.getMovement(exciseRegistrationNumber, arc).map {
-        case Right(response) => Ok(viewMovementPage(exciseRegistrationNumber, arc, response))
-        case Left(_) => InternalServerError(errorHandler.standardErrorTemplate())
-      }
-    }
+  def exciseNumber(): Action[AnyContent] = Action {
+    NotImplemented
+  }
+
+//  def exiseNumber(): Action[AnyContent] = authAction.async { implicit request =>
+//    authAction.checkErnMatchesRequest(exciseRegistrationNumber) {
+//      connector.getMovement(exciseRegistrationNumber, arc).map {
+//        case Right(response) => Ok(viewMovementPage(exciseRegistrationNumber, arc, response))
+//        case Left(_) => InternalServerError(errorHandler.standardErrorTemplate())
+//      }
+//    }
+//  }
 }

--- a/app/uk/gov/hmrc/emcstfefrontend/controllers/ModeOfTransportController.scala
+++ b/app/uk/gov/hmrc/emcstfefrontend/controllers/ModeOfTransportController.scala
@@ -18,7 +18,6 @@ package uk.gov.hmrc.emcstfefrontend.controllers
 
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.emcstfefrontend.config.ErrorHandler
-import uk.gov.hmrc.emcstfefrontend.controllers.predicates.AuthAction
 import uk.gov.hmrc.emcstfefrontend.services.ModeOfTransportService
 import uk.gov.hmrc.emcstfefrontend.views.html.ModeOfTransportPage
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -30,11 +29,10 @@ import scala.concurrent.ExecutionContext
 class ModeOfTransportController @Inject()(mcc: MessagesControllerComponents,
                                           service: ModeOfTransportService,
                                           modeOfTransportPage: ModeOfTransportPage,
-                                          errorHandler: ErrorHandler,
-                                          authAction: AuthAction
+                                          errorHandler: ErrorHandler
                                          )(implicit val executionContext: ExecutionContext) extends FrontendController(mcc) {
 
-  def modeOfTransport(): Action[AnyContent] = authAction.async { implicit request =>
+  def modeOfTransport(): Action[AnyContent] = Action.async { implicit request =>
 
     service.getOtherDataReferenceList map {
       case Right(response) =>

--- a/app/uk/gov/hmrc/emcstfefrontend/controllers/ViewMovementListController.scala
+++ b/app/uk/gov/hmrc/emcstfefrontend/controllers/ViewMovementListController.scala
@@ -34,12 +34,11 @@ class ViewMovementListController @Inject()(mcc: MessagesControllerComponents,
                                            authAction: AuthAction
                                           )(implicit val executionContext: ExecutionContext) extends FrontendController(mcc) {
 
-  def viewMovementList(exciseRegistrationNumber: String): Action[AnyContent] = authAction.async { implicit request =>
-    authAction.checkErnMatchesRequest(exciseRegistrationNumber) {
+  def viewMovementList(exciseRegistrationNumber: String): Action[AnyContent] =
+    authAction(exciseRegistrationNumber).async { implicit request =>
       connector.getMovementList(exciseRegistrationNumber).map {
         case Right(movementList) => Ok(viewMovementListPage(exciseRegistrationNumber, movementList))
         case Left(_) => InternalServerError(errorHandler.internalServerErrorTemplate)
       }
     }
-  }
 }

--- a/app/uk/gov/hmrc/emcstfefrontend/controllers/predicates/SelectExciseNumberAuthAction.scala
+++ b/app/uk/gov/hmrc/emcstfefrontend/controllers/predicates/SelectExciseNumberAuthAction.scala
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.emcstfefrontend.controllers.predicates
+
+import com.google.inject.Inject
+import play.api.i18n.MessagesApi
+import play.api.mvc.Results._
+import play.api.mvc._
+import uk.gov.hmrc.auth.core.AffinityGroup.Organisation
+import uk.gov.hmrc.auth.core._
+import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals
+import uk.gov.hmrc.auth.core.retrieve.~
+import uk.gov.hmrc.emcstfefrontend.config.{AppConfig, EnrolmentKeys}
+import uk.gov.hmrc.emcstfefrontend.controllers
+import uk.gov.hmrc.emcstfefrontend.models.auth.ExciseEnrolmentsRequest
+import uk.gov.hmrc.emcstfefrontend.utils.Logging
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.play.http.HeaderCarrierConverter
+
+import javax.inject.Singleton
+import scala.concurrent.{ExecutionContext, Future}
+
+trait SelectExciseNumberAuthAction extends ActionBuilder[ExciseEnrolmentsRequest, AnyContent] with ActionFunction[Request, ExciseEnrolmentsRequest] with Logging
+
+@Singleton
+class SelectExciseNumberAuthActionImpl @Inject()(override val authConnector: AuthConnector,
+                                                 override val parser: BodyParsers.Default,
+                                                 config: AppConfig
+                                                )(implicit override val executionContext: ExecutionContext, val messagesApi: MessagesApi) extends SelectExciseNumberAuthAction with AuthorisedFunctions {
+
+  override def invokeBlock[A](request: Request[A], block: ExciseEnrolmentsRequest[A] => Future[Result]): Future[Result] = {
+
+    implicit val hc: HeaderCarrier = HeaderCarrierConverter.fromRequestAndSession(
+      session = request.session,
+      request = request
+    )
+
+    authorised().retrieve(Retrievals.affinityGroup and Retrievals.allEnrolments and Retrievals.internalId and Retrievals.credentials) {
+
+      case Some(Organisation) ~ enrolments ~ Some(internalId) ~ Some(credentials) =>
+        val exciseEnrolments = enrolments.enrolments.filter(enrolment =>
+          enrolment.key == EnrolmentKeys.EMCS_ENROLMENT && enrolment.isActivated
+        )
+
+        if(exciseEnrolments.isEmpty) {
+          logger.warn(s"[invokeBlock] User has no Active EMCS Enrolments")
+          Future.successful(Redirect(controllers.errors.routes.UnauthorisedController.unauthorised()))
+        } else {
+          val exciseEnrolmentsRequest = ExciseEnrolmentsRequest(request, exciseEnrolments, internalId, credentials.providerId)
+          block(exciseEnrolmentsRequest)
+        }
+      case Some(Organisation) ~ _ ~ None ~ _ =>
+        logger.warn("[invokeBlock] InternalId could not be retrieved from Auth")
+        Future.successful(Redirect(controllers.errors.routes.UnauthorisedController.unauthorised()))
+
+      case Some(Organisation) ~ _ ~ _ ~ None =>
+        logger.warn("[invokeBlock] Credentials could not be retrieved from Auth")
+        Future.successful(Redirect(controllers.errors.routes.UnauthorisedController.unauthorised()))
+
+      case Some(affinityGroup) ~ _ ~ _ ~ _ =>
+        logger.warn(s"[invokeBlock] User has incompatible AffinityGroup of '$affinityGroup'")
+        Future.successful(Redirect(controllers.errors.routes.UnauthorisedController.unauthorised()))
+
+      case _ =>
+        logger.warn(s"[invokeBlock] User has no AffinityGroup")
+        Future.successful(Redirect(controllers.errors.routes.UnauthorisedController.unauthorised()))
+
+    } recover {
+      case _: NoActiveSession =>
+        Redirect(config.loginUrl, Map("continue" -> Seq(config.loginContinueUrl)))
+      case x: AuthorisationException =>
+        logger.debug(s"[invokeBlock] Authorisation Exception ${x.reason}")
+        Redirect(controllers.errors.routes.UnauthorisedController.unauthorised())
+    }
+  }
+}

--- a/app/uk/gov/hmrc/emcstfefrontend/models/auth/ExciseEnrolmentsRequest.scala
+++ b/app/uk/gov/hmrc/emcstfefrontend/models/auth/ExciseEnrolmentsRequest.scala
@@ -1,4 +1,4 @@
-@*
+/*
  * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,22 +12,15 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *@
+ */
 
-@import uk.gov.hmrc.emcstfefrontend.views.html.components._
-@import uk.gov.hmrc.emcstfefrontend.views.html.templates.Layout
+package uk.gov.hmrc.emcstfefrontend.models.auth
 
-@this(
-        layout: Layout,
-        h1: h1,
-        p: p,
-)
-@(pageTitle: String, heading: String, message: String)(implicit request: Request[_], messages: Messages)
-@layout(pageTitle = Some(messages(pageTitle))) {
-    @h1()(Html(messages(heading)))
-    @p(messages(message))
-}
+import play.api.i18n.MessagesApi
+import play.api.mvc.{MessagesRequestHeader, PreferredMessagesProvider, Request, WrappedRequest}
+import uk.gov.hmrc.auth.core.Enrolment
 
-@{
-    //$COVERAGE-OFF$
-}
+case class ExciseEnrolmentsRequest[A](request: Request[A],
+                                      exciseEnrolments: Set[Enrolment],
+                                      internalId: String,
+                                      credId: String)(implicit val messagesApi: MessagesApi) extends WrappedRequest[A](request) with PreferredMessagesProvider with MessagesRequestHeader

--- a/app/uk/gov/hmrc/emcstfefrontend/views/ExciseNumbersPage.scala.html
+++ b/app/uk/gov/hmrc/emcstfefrontend/views/ExciseNumbersPage.scala.html
@@ -19,13 +19,29 @@
 
 @this(
         layout: Layout,
+        bullets: bullets,
         h1: h1,
         p: p,
+        link: link
 )
-@(pageTitle: String, heading: String, message: String)(implicit request: Request[_], messages: Messages)
-@layout(pageTitle = Some(messages(pageTitle))) {
-    @h1()(Html(messages(heading)))
-    @p(messages(message))
+@(exciseNumbers: Set[String])(implicit request: Request[_], messages: Messages)
+
+@layout(pageTitle = Some(messages("exciseNumbers.title"))) {
+
+    @h1(classes = "govuk-heading-l") {
+        @messages("exciseNumbers.heading")
+    }
+
+    @p(messages("exciseNumbers.p1"))
+
+    @p(messages("exciseNumbers.p2"))
+
+    @bullets(exciseNumbers.map { ern =>
+      link(
+          uk.gov.hmrc.emcstfefrontend.controllers.routes.ViewMovementListController.viewMovementList(ern).url,
+          ern
+      )
+    }.toSeq)
 }
 
 @{

--- a/app/uk/gov/hmrc/emcstfefrontend/views/ViewMovementListPage.scala.html
+++ b/app/uk/gov/hmrc/emcstfefrontend/views/ViewMovementListPage.scala.html
@@ -31,7 +31,7 @@
 
 @layout(pageTitle = Some(messages("viewMovementList.title"))) {
 
-    @h1 {
+    @h1() {
         @messages("viewMovementList.heading")
         @span(
          content = s"(${getMovementListResponse.count})",

--- a/app/uk/gov/hmrc/emcstfefrontend/views/ViewMovementPage.scala.html
+++ b/app/uk/gov/hmrc/emcstfefrontend/views/ViewMovementPage.scala.html
@@ -36,7 +36,7 @@
 
 @layout(pageTitle = Some(messages("viewMovement.title")), fullWidthContent = true) {
     @span(messages("common.arc"))
-    @h1(Html(arc))
+    @h1()(Html(arc))
     @h2(messages("viewMovement.heading"))
     @summaryList(
         Seq(

--- a/app/uk/gov/hmrc/emcstfefrontend/views/components/bullets.scala.html
+++ b/app/uk/gov/hmrc/emcstfefrontend/views/components/bullets.scala.html
@@ -14,20 +14,12 @@
  * limitations under the License.
  *@
 
-@import uk.gov.hmrc.emcstfefrontend.views.html.components._
-@import uk.gov.hmrc.emcstfefrontend.views.html.templates.Layout
+@this()
 
-@this(
-        layout: Layout,
-        h1: h1,
-        p: p,
-)
-@(pageTitle: String, heading: String, message: String)(implicit request: Request[_], messages: Messages)
-@layout(pageTitle = Some(messages(pageTitle))) {
-    @h1()(Html(messages(heading)))
-    @p(messages(message))
-}
+@(content: Seq[Html])
 
-@{
-    //$COVERAGE-OFF$
-}
+<ul class="govuk-list govuk-list--bullet">
+ @content.map { bullet =>
+  <li>@bullet</li>
+ }
+</ul>

--- a/app/uk/gov/hmrc/emcstfefrontend/views/components/h1.scala.html
+++ b/app/uk/gov/hmrc/emcstfefrontend/views/components/h1.scala.html
@@ -16,7 +16,7 @@
 
 @this()
 
-@(msg: Html, classes: String = "govuk-heading-xl", id: Option[String] = None)
+@(classes: String = "govuk-heading-xl", id: Option[String] = None)(msg: Html)
 
 <h1 @id.map(value => s"id=$value") class="@classes">@msg</h1>
 

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -6,6 +6,8 @@
 
 GET         /assets/*file                                      controllers.Assets.versioned(path = "/public", file: Asset)
 
+GET         /                                                  uk.gov.hmrc.emcstfefrontend.controllers.IndexController.exciseNumber()
+
 GET         /mode-of-transport                                 uk.gov.hmrc.emcstfefrontend.controllers.ModeOfTransportController.modeOfTransport
 POST        /mode-of-transport                                 uk.gov.hmrc.emcstfefrontend.controllers.ModeOfTransportController.onSubmit
 

--- a/conf/messages
+++ b/conf/messages
@@ -31,3 +31,8 @@ viewMovementList.table.consignor = Consignor
 errors.unauthorised.title = Unauthorised
 errors.unauthorised.heading = Unauthorised
 errors.unauthorised.message = You are not authorised to access this service
+
+exciseNumbers.title = Select a trader Excise Registration Number to use for EMCS
+exciseNumbers.heading = Select a trader Excise Registration Number to use for EMCS
+exciseNumbers.p1 = There are multiple EMCS Excise Registration Number associated with this login.
+exciseNumbers.p2 = Select an Excise Registration Number to continue to EMCS.

--- a/it/uk/gov/hmrc/emcstfefrontend/ModeOfTransportIntegrationSpec.scala
+++ b/it/uk/gov/hmrc/emcstfefrontend/ModeOfTransportIntegrationSpec.scala
@@ -41,86 +41,71 @@ class ModeOfTransportIntegrationSpec extends IntegrationBaseSpec with ModeOfTran
     }
   }
 
-  "Calling the mode of transport page" when {
+  "Calling the mode of transport page" must {
 
-    "user is unauthorised" must {
-      "redirect to the Unauthorised controller" in new Test {
-
+    "return a success page" when {
+      "all downstream calls are successful" in new Test {
         override def setupStubs(): StubMapping = {
-          AuthStub.unauthorised()
+          AuthStub.authorised()
+          DownstreamStub.onSuccess(DownstreamStub.GET, referenceDataUri, Status.OK, validModeOfTransportListJson)
         }
 
         val response: WSResponse = await(request().get())
-        response.status shouldBe Status.SEE_OTHER
-        response.header(HeaderNames.LOCATION) shouldBe Some(controllers.errors.routes.UnauthorisedController.unauthorised().url)
+        response.status shouldBe Status.OK
+        response.body should include("Other")
+        response.body should include("Postal consignment")
       }
     }
+    "return an error page" when {
+      "downstream call returns unexpected JSON" in new Test {
+        val referenceDataResponseBody: JsValue = Json.parse(
+          s"""
+             |{
+             |   "field": "test message"
+             |}
+             |""".stripMargin
+        )
 
-    "user is authorised" when {
-      "return a success page" when {
-        "all downstream calls are successful" in new Test {
-          override def setupStubs(): StubMapping = {
-            AuthStub.authorised()
-            DownstreamStub.onSuccess(DownstreamStub.GET, referenceDataUri, Status.OK, validModeOfTransportListJson)
-          }
-
-          val response: WSResponse = await(request().get())
-          response.status shouldBe Status.OK
-          response.body should include("Other")
-          response.body should include("Postal consignment")
+        override def setupStubs(): StubMapping = {
+          AuthStub.authorised()
+          DownstreamStub.onSuccess(DownstreamStub.GET, referenceDataUri, Status.OK, referenceDataResponseBody)
         }
+
+        val response: WSResponse = await(request().get())
+        response.status shouldBe Status.INTERNAL_SERVER_ERROR
+        response.body should include("Sorry, we’re experiencing technical difficulties")
       }
-      "return an error page" when {
-        "downstream call returns unexpected JSON" in new Test {
-          val referenceDataResponseBody: JsValue = Json.parse(
-            s"""
-               |{
-               |   "field": "test message"
-               |}
-               |""".stripMargin
-          )
 
-          override def setupStubs(): StubMapping = {
-            AuthStub.authorised()
-            DownstreamStub.onSuccess(DownstreamStub.GET, referenceDataUri, Status.OK, referenceDataResponseBody)
-          }
+      "downstream call returns something other than JSON" in new Test {
+        val referenceDataResponseBody: Elem = <message>test message</message>
 
-          val response: WSResponse = await(request().get())
-          response.status shouldBe Status.INTERNAL_SERVER_ERROR
-          response.body should include("Sorry, we’re experiencing technical difficulties")
+        override def setupStubs(): StubMapping = {
+          AuthStub.authorised()
+          DownstreamStub.onSuccess(DownstreamStub.GET, referenceDataUri, Status.OK, referenceDataResponseBody)
         }
 
-        "downstream call returns something other than JSON" in new Test {
-          val referenceDataResponseBody: Elem = <message>test message</message>
+        val response: WSResponse = await(request().get())
+        response.status shouldBe Status.INTERNAL_SERVER_ERROR
+        response.header("Content-Type") shouldBe Some("text/html; charset=UTF-8")
+        response.body should include("Sorry, we’re experiencing technical difficulties")
+      }
+      "downstream call returns a non-200 HTTP response" in new Test {
+        val referenceDataResponseBody: JsValue = Json.parse(
+          s"""
+             |{
+             |   "message": "test message"
+             |}
+             |""".stripMargin
+        )
 
-          override def setupStubs(): StubMapping = {
-            AuthStub.authorised()
-            DownstreamStub.onSuccess(DownstreamStub.GET, referenceDataUri, Status.OK, referenceDataResponseBody)
-          }
-
-          val response: WSResponse = await(request().get())
-          response.status shouldBe Status.INTERNAL_SERVER_ERROR
-          response.header("Content-Type") shouldBe Some("text/html; charset=UTF-8")
-          response.body should include("Sorry, we’re experiencing technical difficulties")
+        override def setupStubs(): StubMapping = {
+          AuthStub.authorised()
+          DownstreamStub.onSuccess(DownstreamStub.GET, referenceDataUri, Status.INTERNAL_SERVER_ERROR, referenceDataResponseBody)
         }
-        "downstream call returns a non-200 HTTP response" in new Test {
-          val referenceDataResponseBody: JsValue = Json.parse(
-            s"""
-               |{
-               |   "message": "test message"
-               |}
-               |""".stripMargin
-          )
 
-          override def setupStubs(): StubMapping = {
-            AuthStub.authorised()
-            DownstreamStub.onSuccess(DownstreamStub.GET, referenceDataUri, Status.INTERNAL_SERVER_ERROR, referenceDataResponseBody)
-          }
-
-          val response: WSResponse = await(request().get())
-          response.status shouldBe Status.INTERNAL_SERVER_ERROR
-          response.body should include("Sorry, we’re experiencing technical difficulties")
-        }
+        val response: WSResponse = await(request().get())
+        response.status shouldBe Status.INTERNAL_SERVER_ERROR
+        response.body should include("Sorry, we’re experiencing technical difficulties")
       }
     }
   }

--- a/it/uk/gov/hmrc/emcstfefrontend/ModeOfTransportIntegrationSpec.scala
+++ b/it/uk/gov/hmrc/emcstfefrontend/ModeOfTransportIntegrationSpec.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.emcstfefrontend
 
 import com.github.tomakehurst.wiremock.stubbing.StubMapping
-import play.api.http.{HeaderNames, Status}
+import play.api.http.Status
 import play.api.libs.json.{JsValue, Json}
 import play.api.libs.ws.{WSRequest, WSResponse}
 import uk.gov.hmrc.emcstfefrontend.fixtures.ModeOfTransportListFixture

--- a/it/uk/gov/hmrc/emcstfefrontend/ViewMovementIntegrationSpec.scala
+++ b/it/uk/gov/hmrc/emcstfefrontend/ViewMovementIntegrationSpec.scala
@@ -32,8 +32,8 @@ class ViewMovementIntegrationSpec extends IntegrationBaseSpec with ModeOfTranspo
   private trait Test {
     def setupStubs(): StubMapping
 
-    def uri: String = s"/consignment/$ern/$arc"
-    def emcsTfeUri: String = s"/emcs-tfe/movement/$ern/$arc"
+    def uri: String = s"/consignment/$testErn/$testArc"
+    def emcsTfeUri: String = s"/emcs-tfe/movement/$testErn/$testArc"
 
     def request(): WSRequest = {
       setupStubs()
@@ -88,7 +88,7 @@ class ViewMovementIntegrationSpec extends IntegrationBaseSpec with ModeOfTranspo
           val response: WSResponse = await(request().get())
           response.status shouldBe Status.OK
           response.body should include("Administrative reference code")
-          response.body should include(arc)
+          response.body should include(testArc)
         }
       }
       "return an error page" when {

--- a/it/uk/gov/hmrc/emcstfefrontend/ViewMovementListIntegrationSpec.scala
+++ b/it/uk/gov/hmrc/emcstfefrontend/ViewMovementListIntegrationSpec.scala
@@ -31,8 +31,8 @@ class ViewMovementListIntegrationSpec extends IntegrationBaseSpec with MovementL
 
   private trait Test {
 
-    val uri: String = "/movements-in/" + ern
-    val emcsTfeUri: String = s"/emcs-tfe/movements/" + ern
+    val uri: String = "/movements-in/" + testErn
+    val emcsTfeUri: String = s"/emcs-tfe/movements/" + testErn
 
     def setupStubs(): StubMapping
 

--- a/it/uk/gov/hmrc/emcstfefrontend/stubs/AuthStub.scala
+++ b/it/uk/gov/hmrc/emcstfefrontend/stubs/AuthStub.scala
@@ -26,7 +26,7 @@ object AuthStub extends DownstreamStub with BaseFixtures {
 
   val authoriseUri = "/auth/authorise"
 
-  def authorised(exciseNumber: String = ern): StubMapping =
+  def authorised(exciseNumber: String = testErn): StubMapping =
     onSuccess(POST, authoriseUri, OK, Json.obj(
         "affinityGroup" -> "Organisation",
         "allEnrolments" -> Json.arr(

--- a/test/uk/gov/hmrc/emcstfefrontend/connectors/emcsTfe/GetMovementListConnectorSpec.scala
+++ b/test/uk/gov/hmrc/emcstfefrontend/connectors/emcsTfe/GetMovementListConnectorSpec.scala
@@ -43,9 +43,9 @@ class GetMovementListConnectorSpec extends UnitSpec with Status with MimeTypes w
 
       "downstream call is successful" in new Test {
 
-        MockHttpClient.get(s"$baseUrl/movements/$ern").returns(Future.successful(getMovementListResponse))
+        MockHttpClient.get(s"$baseUrl/movements/$testErn").returns(Future.successful(getMovementListResponse))
 
-        await(connector.getMovementList(exciseRegistrationNumber = ern)) shouldBe getMovementListResponse
+        await(connector.getMovementList(exciseRegistrationNumber = testErn)) shouldBe getMovementListResponse
       }
     }
   }

--- a/test/uk/gov/hmrc/emcstfefrontend/controllers/IndexControllerSpec.scala
+++ b/test/uk/gov/hmrc/emcstfefrontend/controllers/IndexControllerSpec.scala
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.emcstfefrontend.controllers
+
+import play.api.http.Status
+import play.api.i18n.MessagesApi
+import play.api.mvc.{AnyContentAsEmpty, MessagesControllerComponents, Result}
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import play.twirl.api.Html
+import uk.gov.hmrc.auth.core.{Enrolment, EnrolmentIdentifier}
+import uk.gov.hmrc.emcstfefrontend.config.EnrolmentKeys
+import uk.gov.hmrc.emcstfefrontend.controllers.predicates.FakeSelectExciseNumbersAuthAction
+import uk.gov.hmrc.emcstfefrontend.fixtures.messages.EN
+import uk.gov.hmrc.emcstfefrontend.mocks.connectors.MockEmcsTfeConnector
+import uk.gov.hmrc.emcstfefrontend.support.UnitSpec
+import uk.gov.hmrc.emcstfefrontend.views.html.ExciseNumbersPage
+import uk.gov.hmrc.http.HeaderCarrier
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class IndexControllerSpec extends UnitSpec with FakeSelectExciseNumbersAuthAction {
+
+  val oneEnrolment = Set(
+    Enrolment(
+      key = EnrolmentKeys.EMCS_ENROLMENT,
+      identifiers = Seq(EnrolmentIdentifier(EnrolmentKeys.ERN, testErn)),
+      state = EnrolmentKeys.ACTIVATED
+    )
+  )
+
+  val twoEnrolments = oneEnrolment + Enrolment(
+      key = EnrolmentKeys.EMCS_ENROLMENT,
+      identifiers = Seq(EnrolmentIdentifier(EnrolmentKeys.ERN, testErn + "_2")),
+      state = EnrolmentKeys.ACTIVATED
+    )
+
+  class Test(enrolments: Set[Enrolment]) extends MockEmcsTfeConnector {
+    implicit val hc: HeaderCarrier = HeaderCarrier()
+    implicit val ec: ExecutionContext = app.injector.instanceOf[ExecutionContext]
+    implicit val fakeRequest: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("GET", "/")
+    implicit val messages = app.injector.instanceOf[MessagesApi].preferred(Seq(EN.lang))
+
+    val view = app.injector.instanceOf[ExciseNumbersPage]
+    val fakeAuthSuccess = new FakeSuccessSelectExciseNumbersAuthAction(enrolments)
+
+    val controller: IndexController = new IndexController(
+      app.injector.instanceOf[MessagesControllerComponents],
+      view,
+      fakeAuthSuccess
+    )
+  }
+
+  ".exciseNumber()" when {
+
+    "Auth returns one EMCS enrolment" should {
+
+      "return 303 and redirect movements-in page" in new Test(oneEnrolment) {
+
+        val result: Future[Result] = controller.exciseNumber()(fakeRequest)
+
+        status(result) shouldBe Status.SEE_OTHER
+        redirectLocation(result) shouldBe Some(routes.ViewMovementListController.viewMovementList(testErn).url)
+      }
+    }
+
+    "Auth returns no EMCS enrolments" should {
+
+      "return 303 and redirect to the unauthorised page" in new Test(Set()) {
+
+        val result: Future[Result] = controller.exciseNumber()(fakeRequest)
+
+        status(result) shouldBe Status.SEE_OTHER
+        redirectLocation(result) shouldBe Some(errors.routes.UnauthorisedController.unauthorised().url)
+      }
+    }
+
+    "Auth returns more than one EMCS enrolment" should {
+
+      "return OK and render the ExciseNumbers page" in new Test(twoEnrolments) {
+
+        val result: Future[Result] = controller.exciseNumber()(fakeRequest)
+
+        status(result) shouldBe Status.OK
+        Html(contentAsString(result)) shouldBe view(Set(testErn, testErn + "_2"))
+      }
+    }
+  }
+}

--- a/test/uk/gov/hmrc/emcstfefrontend/controllers/ModeOfTransportControllerSpec.scala
+++ b/test/uk/gov/hmrc/emcstfefrontend/controllers/ModeOfTransportControllerSpec.scala
@@ -43,8 +43,7 @@ class ModeOfTransportControllerSpec extends UnitSpec with ModeOfTransportListFix
       mcc = app.injector.instanceOf[MessagesControllerComponents],
       service = mockService,
       modeOfTransportPage = app.injector.instanceOf[ModeOfTransportPage],
-      errorHandler = app.injector.instanceOf[ErrorHandler],
-      authAction = FakeSuccessAuthAction
+      errorHandler = app.injector.instanceOf[ErrorHandler]
     )
   }
 

--- a/test/uk/gov/hmrc/emcstfefrontend/controllers/ViewMovementControllerSpec.scala
+++ b/test/uk/gov/hmrc/emcstfefrontend/controllers/ViewMovementControllerSpec.scala
@@ -58,7 +58,7 @@ class ViewMovementControllerSpec extends UnitSpec with FakeAuthAction {
           .getMovement()
           .returns(Future.successful(Right(model)))
 
-        val result: Future[Result] = controller.viewMovement(ern, arc)(fakeRequest)
+        val result: Future[Result] = controller.viewMovement(testErn, testArc)(fakeRequest)
 
         status(result) shouldBe Status.OK
       }
@@ -70,7 +70,7 @@ class ViewMovementControllerSpec extends UnitSpec with FakeAuthAction {
           .getMovement()
           .returns(Future.successful(Left(UnexpectedDownstreamResponseError)))
 
-        val result: Future[Result] = controller.viewMovement(ern, arc)(fakeRequest)
+        val result: Future[Result] = controller.viewMovement(testErn, testArc)(fakeRequest)
 
         status(result) shouldBe Status.INTERNAL_SERVER_ERROR
       }

--- a/test/uk/gov/hmrc/emcstfefrontend/controllers/ViewMovementListControllerSpec.scala
+++ b/test/uk/gov/hmrc/emcstfefrontend/controllers/ViewMovementListControllerSpec.scala
@@ -61,13 +61,13 @@ class ViewMovementListControllerSpec extends UnitSpec with MovementListFixtures 
       "return 200" in new Test {
 
         MockEmcsTfeConnector
-          .getMovementList(ern)
+          .getMovementList(testErn)
           .returns(Future.successful(Right(getMovementListResponse)))
 
-        val result: Future[Result] = controller.viewMovementList(ern)(fakeRequest)
+        val result: Future[Result] = controller.viewMovementList(testErn)(fakeRequest)
 
         status(result) shouldBe Status.OK
-        Html(contentAsString(result)) shouldBe view(ern, getMovementListResponse)
+        Html(contentAsString(result)) shouldBe view(testErn, getMovementListResponse)
       }
     }
 
@@ -76,10 +76,10 @@ class ViewMovementListControllerSpec extends UnitSpec with MovementListFixtures 
       "return 500" in new Test {
 
         MockEmcsTfeConnector
-          .getMovementList(ern)
+          .getMovementList(testErn)
           .returns(Future.successful(Left(UnexpectedDownstreamResponseError)))
 
-        val result: Future[Result] = controller.viewMovementList(ern)(fakeRequest)
+        val result: Future[Result] = controller.viewMovementList(testErn)(fakeRequest)
 
         status(result) shouldBe Status.INTERNAL_SERVER_ERROR
         Html(contentAsString(result)) shouldBe errorHandler.internalServerErrorTemplate

--- a/test/uk/gov/hmrc/emcstfefrontend/controllers/predicates/FakeAuthAction.scala
+++ b/test/uk/gov/hmrc/emcstfefrontend/controllers/predicates/FakeAuthAction.scala
@@ -32,11 +32,18 @@ trait FakeAuthAction extends StubBodyParserFactory with BaseFixtures { _: UnitSp
 
   object FakeSuccessAuthAction extends AuthAction {
 
-    override implicit protected def executionContext: ExecutionContext = ec
+    override def apply(ern: String): ActionBuilder[UserRequest, AnyContent] with ActionFunction[Request, UserRequest] =
 
-    override def parser: BodyParser[AnyContent] = stubBodyParser()
+      new ActionBuilder[UserRequest, AnyContent] with ActionFunction[Request, UserRequest] {
 
-    override def invokeBlock[A](request: Request[A], block: UserRequest[A] => Future[Result]): Future[Result] =
-      block(UserRequest(request, ern, testInternalId, testCredId))
+        override def invokeBlock[A](request: Request[A], block: UserRequest[A] => Future[Result]): Future[Result] =
+          block(UserRequest(request, ern, testInternalId, testCredId))
+
+        override def parser: BodyParser[AnyContent] =
+          stubBodyParser()
+
+        override protected def executionContext: ExecutionContext =
+          scala.concurrent.ExecutionContext.Implicits.global
+      }
   }
 }

--- a/test/uk/gov/hmrc/emcstfefrontend/controllers/predicates/FakeFailingAuthConnector.scala
+++ b/test/uk/gov/hmrc/emcstfefrontend/controllers/predicates/FakeFailingAuthConnector.scala
@@ -1,4 +1,4 @@
-@*
+/*
  * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,18 +12,19 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *@
+ */
 
-@this()
+package uk.gov.hmrc.emcstfefrontend.controllers.predicates
 
-@(content: Seq[Html])
+import com.google.inject.Inject
+import uk.gov.hmrc.auth.core.AuthConnector
+import uk.gov.hmrc.auth.core.authorise.Predicate
+import uk.gov.hmrc.auth.core.retrieve.Retrieval
+import uk.gov.hmrc.http.HeaderCarrier
 
-<ul class="govuk-list govuk-list--bullet">
- @content.map { bullet =>
-  <li>@bullet</li>
- }
-</ul>
+import scala.concurrent.{ExecutionContext, Future}
 
-@{
- //$COVERAGE-OFF$
+class FakeFailingAuthConnector @Inject()(exceptionToReturn: Throwable) extends AuthConnector {
+  override def authorise[A](predicate: Predicate, retrieval: Retrieval[A])(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[A] =
+    Future.failed(exceptionToReturn)
 }

--- a/test/uk/gov/hmrc/emcstfefrontend/controllers/predicates/FakeSelectExciseNumbersAuthAction.scala
+++ b/test/uk/gov/hmrc/emcstfefrontend/controllers/predicates/FakeSelectExciseNumbersAuthAction.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.emcstfefrontend.controllers.predicates
+
+import play.api.i18n.MessagesApi
+import play.api.mvc._
+import play.api.test.StubBodyParserFactory
+import uk.gov.hmrc.auth.core.Enrolment
+import uk.gov.hmrc.emcstfefrontend.fixtures.BaseFixtures
+import uk.gov.hmrc.emcstfefrontend.models.auth.ExciseEnrolmentsRequest
+import uk.gov.hmrc.emcstfefrontend.support.UnitSpec
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait FakeSelectExciseNumbersAuthAction extends StubBodyParserFactory with BaseFixtures { _: UnitSpec =>
+
+  implicit lazy val messagesApi = app.injector.instanceOf[MessagesApi]
+  implicit lazy val ec = app.injector.instanceOf[ExecutionContext]
+
+  class FakeSuccessSelectExciseNumbersAuthAction(enrolments: Set[Enrolment]) extends SelectExciseNumberAuthAction {
+
+    override def invokeBlock[A](request: Request[A], block: ExciseEnrolmentsRequest[A] => Future[Result]): Future[Result] =
+      block(ExciseEnrolmentsRequest(request, enrolments, testInternalId, testCredId))
+
+    override def parser: BodyParser[AnyContent] =
+      stubBodyParser()
+
+    override protected def executionContext: ExecutionContext =
+      scala.concurrent.ExecutionContext.Implicits.global
+  }
+}

--- a/test/uk/gov/hmrc/emcstfefrontend/controllers/predicates/FakeSuccessAuthConnector.scala
+++ b/test/uk/gov/hmrc/emcstfefrontend/controllers/predicates/FakeSuccessAuthConnector.scala
@@ -1,4 +1,4 @@
-@*
+/*
  * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,18 +12,19 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *@
+ */
 
-@this()
+package uk.gov.hmrc.emcstfefrontend.controllers.predicates
 
-@(content: Seq[Html])
+import com.google.inject.Inject
+import uk.gov.hmrc.auth.core.AuthConnector
+import uk.gov.hmrc.auth.core.authorise.Predicate
+import uk.gov.hmrc.auth.core.retrieve.Retrieval
+import uk.gov.hmrc.http.HeaderCarrier
 
-<ul class="govuk-list govuk-list--bullet">
- @content.map { bullet =>
-  <li>@bullet</li>
- }
-</ul>
+import scala.concurrent.{ExecutionContext, Future}
 
-@{
- //$COVERAGE-OFF$
+class FakeSuccessAuthConnector[B] @Inject()(response: B) extends AuthConnector {
+  override def authorise[A](predicate: Predicate, retrieval: Retrieval[A])(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[A] =
+    Future.successful(response.asInstanceOf[A])
 }

--- a/test/uk/gov/hmrc/emcstfefrontend/fixtures/BaseFixtures.scala
+++ b/test/uk/gov/hmrc/emcstfefrontend/fixtures/BaseFixtures.scala
@@ -18,8 +18,8 @@ package uk.gov.hmrc.emcstfefrontend.fixtures
 
 trait BaseFixtures {
 
-  val ern = "ERN"
-  val arc = "ARC"
+  val testErn = "ERN"
+  val testArc = "ARC"
   val testCredId = "cred1234567891"
   val testInternalId = "int1234567891"
 

--- a/test/uk/gov/hmrc/emcstfefrontend/fixtures/messages/ExciseNumbersMessages.scala
+++ b/test/uk/gov/hmrc/emcstfefrontend/fixtures/messages/ExciseNumbersMessages.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.emcstfefrontend.fixtures.messages
+
+object ExciseNumbersMessages {
+
+  sealed trait ViewMessages { _: i18n =>
+    val title: String
+    val heading: String
+    val p1: String
+    val p2: String
+  }
+
+  object English extends ViewMessages with EN {
+    override val title: String = "Select a trader Excise Registration Number to use for EMCS"
+    override val heading: String = "Select a trader Excise Registration Number to use for EMCS"
+    override val p1: String = "There are multiple EMCS Excise Registration Number associated with this login."
+    override val p2: String = "Select an Excise Registration Number to continue to EMCS."
+  }
+
+  object Welsh extends ViewMessages with CY {
+    override val title: String = "Select a trader Excise Registration Number to use for EMCS"
+    override val heading: String = "Select a trader Excise Registration Number to use for EMCS"
+    override val p1: String = "There are multiple EMCS Excise Registration Number associated with this login."
+    override val p2: String = "Select an Excise Registration Number to continue to EMCS."
+  }
+}

--- a/test/uk/gov/hmrc/emcstfefrontend/models/GetMovementListItemSpec.scala
+++ b/test/uk/gov/hmrc/emcstfefrontend/models/GetMovementListItemSpec.scala
@@ -37,7 +37,7 @@ class GetMovementListItemSpec extends UnitSpec with MovementListFixtures {
     }
 
     "have a link to view the detailed movement information" in {
-      movement1.viewMovementUrl(ern) shouldBe routes.ViewMovementController.viewMovement(ern, s"${movement1.arc}")
+      movement1.viewMovementUrl(testErn) shouldBe routes.ViewMovementController.viewMovement(testErn, s"${movement1.arc}")
     }
   }
 }

--- a/test/uk/gov/hmrc/emcstfefrontend/viewmodels/MovementsListTableHelperSpec.scala
+++ b/test/uk/gov/hmrc/emcstfefrontend/viewmodels/MovementsListTableHelperSpec.scala
@@ -56,11 +56,11 @@ class MovementsListTableHelperSpec extends UnitSpec with MovementListFixtures wi
 
           "construct the expected data rows" in {
 
-            helper.dataRows(ern, movements) shouldBe Seq(
+            helper.dataRows(testErn, movements) shouldBe Seq(
               Seq(
                 TableRow(
                   content = HtmlContent(link(
-                    link = movement1.viewMovementUrl(ern).url,
+                    link = movement1.viewMovementUrl(testErn).url,
                     messageKey = movement1.arc
                   ))
                 ),
@@ -71,7 +71,7 @@ class MovementsListTableHelperSpec extends UnitSpec with MovementListFixtures wi
               Seq(
                 TableRow(
                   content = HtmlContent(link(
-                    link = movement2.viewMovementUrl(ern).url,
+                    link = movement2.viewMovementUrl(testErn).url,
                     messageKey = movement2.arc
                   ))
                 ),
@@ -87,13 +87,13 @@ class MovementsListTableHelperSpec extends UnitSpec with MovementListFixtures wi
 
           "construct the expected data rows" in {
 
-            helper.constructTable(ern, movements) shouldBe Table(
+            helper.constructTable(testErn, movements) shouldBe Table(
               firstCellIsHeader = true,
               rows = Seq(
                 Seq(
                   TableRow(
                     content = HtmlContent(link(
-                      link = movement1.viewMovementUrl(ern).url,
+                      link = movement1.viewMovementUrl(testErn).url,
                       messageKey = movement1.arc
                     ))
                   ),
@@ -104,7 +104,7 @@ class MovementsListTableHelperSpec extends UnitSpec with MovementListFixtures wi
                 Seq(
                   TableRow(
                     content = HtmlContent(link(
-                      link = movement2.viewMovementUrl(ern).url,
+                      link = movement2.viewMovementUrl(testErn).url,
                       messageKey = movement2.arc
                     ))
                   ),

--- a/test/uk/gov/hmrc/emcstfefrontend/views/ExciseNumbersPageViewSpec.scala
+++ b/test/uk/gov/hmrc/emcstfefrontend/views/ExciseNumbersPageViewSpec.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.emcstfefrontend.views
+
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import play.api.i18n.{Messages, MessagesApi}
+import play.api.test.FakeRequest
+import play.twirl.api.Html
+import uk.gov.hmrc.emcstfefrontend.fixtures.MovementListFixtures
+import uk.gov.hmrc.emcstfefrontend.fixtures.messages.ExciseNumbersMessages
+import uk.gov.hmrc.emcstfefrontend.support.UnitSpec
+import uk.gov.hmrc.emcstfefrontend.views.html.ExciseNumbersPage
+import uk.gov.hmrc.emcstfefrontend.views.html.components.link
+
+class ExciseNumbersPageViewSpec extends UnitSpec with MovementListFixtures {
+
+  implicit val fakeRequest = FakeRequest("GET", "/excise-numbers")
+
+  lazy val page: ExciseNumbersPage = app.injector.instanceOf[ExciseNumbersPage]
+  lazy val link: link = app.injector.instanceOf[link]
+
+  abstract class TestFixture(implicit messages: Messages) {
+    lazy val html: Html = page(Set("ern1", "ern2", "ern3"))
+    lazy val document: Document = Jsoup.parse(html.toString)
+  }
+
+  "The ExciseNumbersPage view" when {
+
+    Seq(ExciseNumbersMessages.English, ExciseNumbersMessages.Welsh) foreach { viewMessages =>
+
+      implicit val messages: Messages = app.injector.instanceOf[MessagesApi].preferred(Seq(viewMessages.lang))
+
+      s"being rendered for ${viewMessages.lang.code}" should {
+
+        s"have the correct title" in new TestFixture {
+          document.title shouldBe viewMessages.title
+        }
+
+        s"have the correct h1" in new TestFixture {
+          document.select("h1").text() shouldBe viewMessages.heading
+        }
+
+        "have the correct p1" in new TestFixture {
+          document.select("p:nth-of-type(1)").text() shouldBe viewMessages.p1
+        }
+
+        "have the correct p2" in new TestFixture {
+          document.select("p:nth-of-type(2)").text() shouldBe viewMessages.p2
+        }
+      }
+    }
+  }
+}

--- a/test/uk/gov/hmrc/emcstfefrontend/views/ViewMovementListPageViewSpec.scala
+++ b/test/uk/gov/hmrc/emcstfefrontend/views/ViewMovementListPageViewSpec.scala
@@ -38,7 +38,7 @@ class ViewMovementListPageViewSpec extends UnitSpec with MovementListFixtures {
     val helper: MovementsListTableHelper = app.injector.instanceOf[MovementsListTableHelper]
     val table: table = app.injector.instanceOf[table]
 
-    lazy val html: Html = page(ern, getMovementListResponse)
+    lazy val html: Html = page(testErn, getMovementListResponse)
     lazy val document: Document = Jsoup.parse(html.toString)
   }
 

--- a/test/uk/gov/hmrc/emcstfefrontend/views/components/H1Spec.scala
+++ b/test/uk/gov/hmrc/emcstfefrontend/views/components/H1Spec.scala
@@ -29,7 +29,7 @@ class H1Spec extends UnitSpec {
 
 
     lazy val h1: h1 = app.injector.instanceOf[h1]
-    lazy val html: Html = h1(Html("some content"), id = id)
+    lazy val html: Html = h1(id = id)(Html("some content"))
     lazy val document: Document = Jsoup.parse(html.toString)
   }
 


### PR DESCRIPTION
**Notes:**
- If no EMCS enrolment, then returns unauthorised
- If only one EMCS enrolment exists, then redirects to the `movements-In` page _(for now)_
- If more than one EMCS enrolment exists, then shows a page with all ERNs to pick from, which link through to `movements-in`
- Also, `emcs-tfe`, `emcs-tfe-report-a-receipt`, `emcs-tfe-reference-data` all need to have their auth logic updated, separate JIRA sub-tasks raised for those.
    - https://github.com/hmrc/emcs-tfe-report-a-receipt-frontend/pull/12
    - https://github.com/hmrc/emcs-tfe/pull/20
    - https://github.com/hmrc/emcs-tfe-reference-data/pull/13 

![Screenshot 2023-02-20 at 17 27 10](https://user-images.githubusercontent.com/16954819/220170143-3902df09-9eed-4386-9d94-482a9838788e.png)
