### PR TITLE
[ETFE-2866] Adding in the Items on the mov screen (no 'Receipt' column)

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -5,3 +5,7 @@ $hmrc-assets-path: "/emcs/account/assets/lib/hmrc-frontend/hmrc/assets/";
 @import "active-trader-info";
 @import "primary-navigation";
 @import "sub-navigation";
+
+.white-space-nowrap {
+  white-space: nowrap;
+}

--- a/app/config/Module.scala
+++ b/app/config/Module.scala
@@ -28,5 +28,7 @@ class Module extends AbstractModule {
     bind(classOf[SelectExciseNumberAuthAction]).to(classOf[SelectExciseNumberAuthActionImpl])
     bind(classOf[GetExciseProductCodesConnector]).to(classOf[GetExciseProductCodesConnectorImpl]).asEagerSingleton()
     bind(classOf[GetMemberStatesConnector]).to(classOf[GetMemberStatesConnectorImpl]).asEagerSingleton()
+    bind(classOf[GetCnCodeInformationConnector]).to(classOf[GetCnCodeInformationConnectorImpl]).asEagerSingleton()
+    bind(classOf[GetItemPackagingTypesConnector]).to(classOf[GetItemPackagingTypesConnectorImpl]).asEagerSingleton()
   }
 }

--- a/app/connectors/emcsTfe/GetMovementConnector.scala
+++ b/app/connectors/emcsTfe/GetMovementConnector.scala
@@ -29,7 +29,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class GetMovementConnector @Inject()(val http: HttpClient,
                                      config: AppConfig) extends EmcsTfeHttpParser[GetMovementResponse] {
 
-  override implicit val reads: Reads[GetMovementResponse] = GetMovementResponse.format
+  override implicit val reads: Reads[GetMovementResponse] = GetMovementResponse.reads
 
   lazy val baseUrl: String = config.emcsTfeBaseUrl
   def getMovement(exciseRegistrationNumber: String, arc: String)(implicit headerCarrier: HeaderCarrier, executionContext: ExecutionContext): Future[Either[ErrorResponse, GetMovementResponse]] = {

--- a/app/connectors/referenceData/CnCodeInformationHttpParser.scala
+++ b/app/connectors/referenceData/CnCodeInformationHttpParser.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors.referenceData
+
+import connectors.BaseConnectorUtils
+import models.requests.CnCodeInformationRequest
+import models.response.referenceData.CnCodeInformationResponse
+import models.response.{ErrorResponse, JsonValidationError, UnexpectedDownstreamResponseError}
+import play.api.http.Status.OK
+import play.api.libs.json.{Reads, Writes}
+import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, HttpReads, HttpResponse}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait CnCodeInformationHttpParser extends BaseConnectorUtils[CnCodeInformationResponse] {
+
+  implicit val reads: Reads[CnCodeInformationResponse] = CnCodeInformationResponse.reads
+
+  def http: HttpClient
+
+  implicit object CnCodeInformationReads extends HttpReads[Either[ErrorResponse, CnCodeInformationResponse]] {
+    override def read(method: String, url: String, response: HttpResponse): Either[ErrorResponse, CnCodeInformationResponse] = {
+      response.status match {
+        case OK =>
+          response.validateJson match {
+            case Some(valid) => Right(valid)
+            case None =>
+              logger.warn(s"[read] Bad JSON response from emcs-tfe-reference-data")
+              Left(JsonValidationError)
+          }
+        case status =>
+          logger.warn(s"[read] Unexpected status from emcs-tfe-reference-data: $status")
+          Left(UnexpectedDownstreamResponseError)
+      }
+    }
+  }
+
+  def post(url: String, body: CnCodeInformationRequest)(implicit hc: HeaderCarrier, ec: ExecutionContext, writes: Writes[CnCodeInformationRequest]): Future[Either[ErrorResponse, CnCodeInformationResponse]] =
+    http.POST[CnCodeInformationRequest, Either[ErrorResponse, CnCodeInformationResponse]](url, body)(writes, CnCodeInformationReads, hc, ec)
+}

--- a/app/connectors/referenceData/GetCnCodeInformationConnector.scala
+++ b/app/connectors/referenceData/GetCnCodeInformationConnector.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors.referenceData
+
+import config.AppConfig
+import models.requests.CnCodeInformationRequest
+import models.response.referenceData.CnCodeInformationResponse
+import models.response.{ErrorResponse, JsonValidationError, UnexpectedDownstreamResponseError}
+import play.api.libs.json.JsResultException
+import uk.gov.hmrc.http.{HeaderCarrier, HttpClient}
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+trait GetCnCodeInformationConnector {
+  def getCnCodeInformation(request: CnCodeInformationRequest)
+                          (implicit headerCarrier: HeaderCarrier,
+                           executionContext: ExecutionContext): Future[Either[ErrorResponse, CnCodeInformationResponse]]
+}
+
+@Singleton
+class GetCnCodeInformationConnectorImpl @Inject()(val http: HttpClient,
+                                              config: AppConfig) extends CnCodeInformationHttpParser with GetCnCodeInformationConnector {
+
+  lazy val baseUrl: String = config.referenceDataBaseUrl
+
+  def getCnCodeInformation(request: CnCodeInformationRequest)
+                          (implicit headerCarrier: HeaderCarrier,
+                           executionContext: ExecutionContext): Future[Either[ErrorResponse, CnCodeInformationResponse]] = {
+    post(baseUrl + "/oracle/cn-code-information", request)
+      .recover {
+        case JsResultException(errors) =>
+          logger.warn(s"[getCnCodeInformation] Bad JSON response from emcs-tfe-reference-data: " + errors)
+          Left(JsonValidationError)
+        case error =>
+          logger.warn(s"[getCnCodeInformation] Unexpected error from reference-data: ${error.getClass} ${error.getMessage}")
+          Left(UnexpectedDownstreamResponseError)
+      }
+  }
+}

--- a/app/connectors/referenceData/GetItemPackagingTypesConnector.scala
+++ b/app/connectors/referenceData/GetItemPackagingTypesConnector.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors.referenceData
+
+import config.AppConfig
+import models.response.referenceData.ItemPackaging
+import models.response.{ErrorResponse, JsonValidationError, UnexpectedDownstreamResponseError}
+import play.api.libs.json.JsResultException
+import uk.gov.hmrc.http.{HeaderCarrier, HttpClient}
+
+import javax.inject.Inject
+import scala.concurrent.{ExecutionContext, Future}
+
+trait GetItemPackagingTypesConnector {
+  def baseUrl: String
+
+  def getItemPackagingTypes(implicit headerCarrier: HeaderCarrier,
+                         executionContext: ExecutionContext): Future[Either[ErrorResponse, Seq[ItemPackaging]]]
+}
+
+class GetItemPackagingTypesConnectorImpl @Inject()(val http: HttpClient,
+                                           config: AppConfig) extends GetItemPackagingTypesHttpParser with GetItemPackagingTypesConnector {
+
+  override def baseUrl: String = config.referenceDataBaseUrl
+
+  override def getItemPackagingTypes(implicit headerCarrier: HeaderCarrier, executionContext: ExecutionContext): Future[Either[ErrorResponse, Seq[ItemPackaging]]] = {
+    get(baseUrl + "/oracle/packaging-types")
+      .recover {
+        case JsResultException(errors) =>
+          logger.warn(s"[getItemPackagingTypes] Bad JSON response from emcs-tfe-reference-data: " + errors)
+          Left(JsonValidationError)
+        case error =>
+          logger.warn(s"[getItemPackagingTypes] Unexpected error from reference-data: ${error.getClass} ${error.getMessage}")
+          Left(UnexpectedDownstreamResponseError)
+      }
+  }
+
+}

--- a/app/connectors/referenceData/GetItemPackagingTypesHttpParser.scala
+++ b/app/connectors/referenceData/GetItemPackagingTypesHttpParser.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors.referenceData
+
+import connectors.BaseConnectorUtils
+import models.response.referenceData.ItemPackaging
+import models.response.{ErrorResponse, JsonValidationError, UnexpectedDownstreamResponseError}
+import play.api.http.Status.OK
+import play.api.libs.json.Reads
+import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, HttpReads, HttpResponse}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait GetItemPackagingTypesHttpParser extends BaseConnectorUtils[Seq[ItemPackaging]] {
+
+  implicit val reads: Reads[Seq[ItemPackaging]] = ItemPackaging.seqReads
+  def http: HttpClient
+
+  class GetItemPackagingTypesReads extends HttpReads[Either[ErrorResponse, Seq[ItemPackaging]]] {
+    override def read(method: String, url: String, response: HttpResponse): Either[ErrorResponse, Seq[ItemPackaging]] = {
+      response.status match {
+        case OK =>
+          response.validateJson match {
+            case Some(valid: Seq[ItemPackaging]) if valid.isDefinedAt(0) => Right(valid)
+            case _ =>
+              logger.warn(s"[read] Bad JSON response from emcs-tfe-reference-data")
+              Left(JsonValidationError)
+          }
+        case status =>
+          logger.warn(s"[read] Unexpected status from emcs-tfe-reference-data: $status")
+          Left(UnexpectedDownstreamResponseError)
+      }
+    }
+  }
+
+  def get(url: String)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Either[ErrorResponse, Seq[ItemPackaging]]] =
+    http.GET[Either[ErrorResponse, Seq[ItemPackaging]]](url)(new GetItemPackagingTypesReads, hc, ec)
+
+}

--- a/app/models/common/AddressModel.scala
+++ b/app/models/common/AddressModel.scala
@@ -16,7 +16,7 @@
 
 package models.common
 
-import play.api.libs.json.{Json, Reads}
+import play.api.libs.json.{Json, OFormat}
 
 case class AddressModel(streetNumber: Option[String],
                         street: Option[String],
@@ -24,5 +24,5 @@ case class AddressModel(streetNumber: Option[String],
                         city: Option[String])
 
 object AddressModel {
-  implicit val reads: Reads[AddressModel] = Json.reads
+  implicit val format: OFormat[AddressModel] = Json.format
 }

--- a/app/models/common/TraderModel.scala
+++ b/app/models/common/TraderModel.scala
@@ -16,7 +16,7 @@
 
 package models.common
 
-import play.api.libs.json.{Json, Reads}
+import play.api.libs.json.{Json, OFormat}
 
 case class TraderModel(traderExciseNumber: String,
                        traderName: String,
@@ -24,5 +24,5 @@ case class TraderModel(traderExciseNumber: String,
 }
 
 object TraderModel {
-  implicit val reads: Reads[TraderModel] = Json.reads
+  implicit val format: OFormat[TraderModel] = Json.format
 }

--- a/app/models/common/TransportDetailsModel.scala
+++ b/app/models/common/TransportDetailsModel.scala
@@ -16,7 +16,7 @@
 
 package models.common
 
-import play.api.libs.json.{Json, OFormat}
+import play.api.libs.json.{Json, Reads}
 
 case class TransportDetailsModel(
     transportUnitCode: String,
@@ -28,5 +28,5 @@ case class TransportDetailsModel(
 
 object TransportDetailsModel {
 
-  implicit val fmt: OFormat[TransportDetailsModel] = Json.format
+  implicit val reads: Reads[TransportDetailsModel] = Json.reads
 }

--- a/app/models/common/UnitOfMeasure.scala
+++ b/app/models/common/UnitOfMeasure.scala
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.common
+
+import play.api.i18n.Messages
+import play.api.libs.json.{Reads, __}
+
+sealed trait UnitOfMeasure {
+
+  def toShortFormatMessage()(implicit messages: Messages): String =
+    messages(s"unitOfMeasure.$this.short")
+
+  def toLongFormatMessage()(implicit messages: Messages): String =
+    messages(s"unitOfMeasure.$this.long")
+}
+
+object UnitOfMeasure {
+
+  case object Kilograms extends WithName("kilograms") with UnitOfMeasure
+
+  case object Litres15 extends WithName("litres15") with UnitOfMeasure
+
+  case object Litres20 extends WithName("litres20") with UnitOfMeasure
+
+  case object Thousands extends WithName("thousands") with UnitOfMeasure
+
+  val values: Seq[UnitOfMeasure] = Seq(
+    Kilograms,
+    Litres15,
+    Litres20,
+    Thousands
+  )
+
+  def apply(code: Int): UnitOfMeasure = code match {
+    case 1 => Kilograms
+    case 2 => Litres15
+    case 3 => Litres20
+    case 4 => Thousands
+    case code =>
+      throw new IllegalArgumentException(s"Invalid argument of '$code' received which can not be mapped to a UnitOfMeasure")
+  }
+
+  def unapply(unitOfMeasure: UnitOfMeasure): Int = unitOfMeasure match {
+    case Kilograms => 1
+    case Litres15 => 2
+    case Litres20 => 3
+    case Thousands => 4
+    case unitOfMeasure =>
+      throw new IllegalArgumentException(s"Invalid argument of '$unitOfMeasure' received which can not be mapped to an Int")
+  }
+
+  implicit val reads: Reads[UnitOfMeasure] = Reads.at[Int](__).map(UnitOfMeasure.apply)
+}

--- a/app/models/requests/CnCodeInformationRequest.scala
+++ b/app/models/requests/CnCodeInformationRequest.scala
@@ -14,15 +14,24 @@
  * limitations under the License.
  */
 
-package models.common
+package models.requests
 
-import play.api.libs.json.{Json, Reads}
+import models.response.emcsTfe.MovementItem
+import play.api.libs.json.{Json, OWrites}
 
-case class TraderModel(traderExciseNumber: String,
-                       traderName: String,
-                       address: AddressModel) {
+case class CnCodeInformationRequest(items: Seq[CnCodeInformationItem])
+
+case class CnCodeInformationItem(productCode: String, cnCode: String)
+
+object CnCodeInformationRequest {
+  implicit val writes: OWrites[CnCodeInformationRequest] = Json.writes
 }
 
-object TraderModel {
-  implicit val reads: Reads[TraderModel] = Json.reads
+object CnCodeInformationItem {
+
+  def apply(items: Seq[MovementItem]): Seq[CnCodeInformationItem] = items.map { item =>
+    CnCodeInformationItem(item.productCode, item.cnCode)
+  }
+
+  implicit val writes: OWrites[CnCodeInformationItem] = Json.writes
 }

--- a/app/models/response/ErrorResponse.scala
+++ b/app/models/response/ErrorResponse.scala
@@ -41,3 +41,9 @@ case class InvalidDestinationTypeException(message: String) extends Exception(me
 case class InvalidUserTypeException(message: String) extends Exception(message) with NoStackTrace with ErrorResponse
 
 case class MissingDispatchPlaceTraderException(message: String) extends Exception(message) with NoStackTrace with ErrorResponse
+
+case class CnCodeInformationException(message: String) extends Exception(message) with NoStackTrace with ErrorResponse
+
+case class PackagingTypesException(message: String) extends Exception(message) with NoStackTrace with ErrorResponse
+
+case class MovementException(message: String) extends Exception(message) with NoStackTrace with ErrorResponse

--- a/app/models/response/emcsTfe/EadEsadModel.scala
+++ b/app/models/response/emcsTfe/EadEsadModel.scala
@@ -17,7 +17,7 @@
 package models.response.emcsTfe
 
 import models.common.OriginType
-import play.api.libs.json.{Json, OFormat}
+import play.api.libs.json.{Json, Reads}
 import utils.DateUtils
 
 import java.time.{LocalDate, LocalTime}
@@ -46,5 +46,5 @@ case class EadEsadModel(
 
 object EadEsadModel {
 
-  implicit val fmt: OFormat[EadEsadModel] = Json.format
+  implicit val reads: Reads[EadEsadModel] = Json.reads
 }

--- a/app/models/response/emcsTfe/GetMovementResponse.scala
+++ b/app/models/response/emcsTfe/GetMovementResponse.scala
@@ -16,6 +16,9 @@
 
 package models.response.emcsTfe
 
+import models.common.{TraderModel, TransportDetailsModel}
+import models.response.emcsTfe.{EadEsadModel, MovementItem}
+import play.api.libs.json.{Json, Reads}
 import models.common.{DestinationType, TraderModel, TransportDetailsModel}
 import models.response.emcsTfe.reportOfReceipt.ReportOfReceiptModel
 import play.api.libs.json.{Json, OFormat}
@@ -40,7 +43,8 @@ case class GetMovementResponse(
                                 journeyTime: String,
                                 numberOfItems: Int,
                                 transportDetails: Seq[TransportDetailsModel],
-                                reportOfReceipt: Option[ReportOfReceiptModel]
+                                reportOfReceipt: Option[ReportOfReceiptModel],
+                                items: Seq[MovementItem]
                               ) extends DateUtils with ExpectedDateOfArrival {
   def formattedDateOfDispatch: String = dateOfDispatch.formatDateForUIOutput()
 
@@ -59,5 +63,5 @@ case class GetMovementResponse(
 }
 
 object GetMovementResponse {
-  implicit val format: OFormat[GetMovementResponse] = Json.format
+  implicit val reads: Reads[GetMovementResponse] = Json.reads
 }

--- a/app/models/response/emcsTfe/GetMovementResponse.scala
+++ b/app/models/response/emcsTfe/GetMovementResponse.scala
@@ -16,12 +16,9 @@
 
 package models.response.emcsTfe
 
-import models.common.{TraderModel, TransportDetailsModel}
-import models.response.emcsTfe.{EadEsadModel, MovementItem}
-import play.api.libs.json.{Json, Reads}
 import models.common.{DestinationType, TraderModel, TransportDetailsModel}
 import models.response.emcsTfe.reportOfReceipt.ReportOfReceiptModel
-import play.api.libs.json.{Json, OFormat}
+import play.api.libs.json.{Json, Reads}
 import utils.{DateUtils, ExpectedDateOfArrival}
 
 import java.time.{LocalDate, LocalTime}

--- a/app/models/response/emcsTfe/MovementItem.scala
+++ b/app/models/response/emcsTfe/MovementItem.scala
@@ -14,15 +14,19 @@
  * limitations under the License.
  */
 
-package models.common
+package models.response.emcsTfe
 
+import models.common.UnitOfMeasure
 import play.api.libs.json.{Json, Reads}
 
-case class AddressModel(streetNumber: Option[String],
-                        street: Option[String],
-                        postcode: Option[String],
-                        city: Option[String])
+case class MovementItem(itemUniqueReference: Int,
+                        productCode: String,
+                        cnCode: String,
+                        quantity: BigDecimal,
+                        commercialDescription: Option[String],
+                        packaging: Seq[Packaging],
+                        unitOfMeasure: Option[UnitOfMeasure])
 
-object AddressModel {
-  implicit val reads: Reads[AddressModel] = Json.reads
+object MovementItem {
+  implicit val reads: Reads[MovementItem] = Json.reads
 }

--- a/app/models/response/emcsTfe/Packaging.scala
+++ b/app/models/response/emcsTfe/Packaging.scala
@@ -14,15 +14,12 @@
  * limitations under the License.
  */
 
-package models.common
+package models.response.emcsTfe
 
 import play.api.libs.json.{Json, Reads}
 
-case class AddressModel(streetNumber: Option[String],
-                        street: Option[String],
-                        postcode: Option[String],
-                        city: Option[String])
-
-object AddressModel {
-  implicit val reads: Reads[AddressModel] = Json.reads
+case class Packaging(typeOfPackage: String,
+                     quantity: Option[BigDecimal])
+object Packaging {
+  implicit val reads: Reads[Packaging] = Json.reads
 }

--- a/app/models/response/emcsTfe/reportOfReceipt/ReportOfReceiptModel.scala
+++ b/app/models/response/emcsTfe/reportOfReceipt/ReportOfReceiptModel.scala
@@ -22,15 +22,15 @@ import play.api.libs.json.{Json, OFormat}
 import java.time.LocalDate
 
 case class ReportOfReceiptModel(arc: String,
-                                      sequenceNumber: Int,
-                                      dateAndTimeOfValidationOfReportOfReceiptExport: Option[String],
-                                      consigneeTrader: Option[TraderModel],
-                                      deliveryPlaceTrader: Option[TraderModel],
-                                      destinationOffice: String,
-                                      dateOfArrival: LocalDate,
-                                      acceptMovement: String,
-                                      individualItems: Seq[ReceiptedItemsModel],
-                                      otherInformation: Option[String])
+                                sequenceNumber: Int,
+                                dateAndTimeOfValidationOfReportOfReceiptExport: Option[String],
+                                consigneeTrader: Option[TraderModel],
+                                deliveryPlaceTrader: Option[TraderModel],
+                                destinationOffice: String,
+                                dateOfArrival: LocalDate,
+                                acceptMovement: String,
+                                individualItems: Seq[ReceiptedItemsModel],
+                                otherInformation: Option[String])
 
 object ReportOfReceiptModel {
   implicit val format: OFormat[ReportOfReceiptModel] = Json.format

--- a/app/models/response/referenceData/CnCodeInformation.scala
+++ b/app/models/response/referenceData/CnCodeInformation.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.response.referenceData
+
+import models.common.UnitOfMeasure
+import play.api.libs.functional.syntax._
+import play.api.libs.json.{JsPath, Reads}
+
+case class CnCodeInformation(cnCode: String,
+                             cnCodeDescription: String,
+                             exciseProductCode: String,
+                             exciseProductCodeDescription: String,
+                             unitOfMeasure: UnitOfMeasure)
+
+object CnCodeInformation {
+  implicit val reads: Reads[CnCodeInformation] = (
+    (JsPath \ "cnCode").read[String] and
+      (JsPath \ "cnCodeDescription").read[String] and
+      (JsPath \ "exciseProductCode").read[String] and
+      (JsPath \ "exciseProductCodeDescription").read[String] and
+      (JsPath \ "unitOfMeasureCode").read[Int].map(UnitOfMeasure.apply)
+    )(CnCodeInformation.apply _)
+}

--- a/app/models/response/referenceData/CnCodeInformationResponse.scala
+++ b/app/models/response/referenceData/CnCodeInformationResponse.scala
@@ -14,15 +14,18 @@
  * limitations under the License.
  */
 
-package models.common
+package models.response.referenceData
 
-import play.api.libs.json.{Json, Reads}
+import play.api.libs.json.{JsError, JsObject, JsSuccess, Reads}
 
-case class AddressModel(streetNumber: Option[String],
-                        street: Option[String],
-                        postcode: Option[String],
-                        city: Option[String])
+case class CnCodeInformationResponse(data: Map[String, CnCodeInformation])
 
-object AddressModel {
-  implicit val reads: Reads[AddressModel] = Json.reads
+object CnCodeInformationResponse {
+  implicit val reads: Reads[CnCodeInformationResponse] = {
+    case JsObject(underlying) => JsSuccess(CnCodeInformationResponse(underlying.map {
+      case (key, value) => (key, value.as[CnCodeInformation])
+    }.toMap))
+    case other =>
+      JsError("Unable to read CnCodeInformationResponse as a JSON object: " + other.toString())
+  }
 }

--- a/app/models/response/referenceData/ItemPackaging.scala
+++ b/app/models/response/referenceData/ItemPackaging.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.response.referenceData
+
+import models.SelectOptionModel
+import play.api.libs.json._
+
+case class ItemPackaging(packagingType: String, description: String) extends SelectOptionModel {
+  override val code: String = packagingType
+  override val displayName: String = s"$description ($code)"
+}
+
+object ItemPackaging {
+
+  implicit val format = Json.format[ItemPackaging]
+
+  implicit val seqReads: Reads[Seq[ItemPackaging]] = {
+    case JsObject(underlying) => JsSuccess(underlying.map {
+      case (key, value) => ItemPackaging(key, value.as[String])
+    }.toSeq)
+    case other =>
+      JsError("Unable to read ItemPackaging as a JSON object: " + other.toString())
+  }
+}

--- a/app/services/GetCnCodeInformationService.scala
+++ b/app/services/GetCnCodeInformationService.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services
+
+import connectors.referenceData.GetCnCodeInformationConnector
+import models.requests.{CnCodeInformationItem, CnCodeInformationRequest}
+import models.response.CnCodeInformationException
+import models.response.emcsTfe.MovementItem
+import models.response.referenceData.{CnCodeInformation, CnCodeInformationResponse}
+import uk.gov.hmrc.http.HeaderCarrier
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class GetCnCodeInformationService @Inject()(connector: GetCnCodeInformationConnector)
+                                           (implicit ec: ExecutionContext) {
+
+  def getCnCodeInformation(items: Seq[MovementItem])(implicit hc: HeaderCarrier): Future[Seq[(MovementItem, CnCodeInformation)]] =
+    connector.getCnCodeInformation(CnCodeInformationRequest(CnCodeInformationItem(items))).map {
+      case Right(response) =>
+        matchMovementItemsWithReferenceDataValues(response, items)
+      case Left(errorResponse) =>
+        throw CnCodeInformationException(s"Failed to retrieve CN Code information: $errorResponse")
+    }
+
+  private def matchMovementItemsWithReferenceDataValues(response: CnCodeInformationResponse,
+                                                        items: Seq[MovementItem]): Seq[(MovementItem, CnCodeInformation)] =
+    items.collect {
+      case item if response.data.contains(item.cnCode) =>
+        item -> response.data(item.cnCode)
+      case item =>
+        throw CnCodeInformationException(s"Failed to match item with CN Code information: $item")
+    }
+}

--- a/app/services/GetMovementService.scala
+++ b/app/services/GetMovementService.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services
+
+import connectors.emcsTfe.GetMovementConnector
+import models.response.MovementException
+import uk.gov.hmrc.emcstfefrontend.models.response.emcsTfe.GetMovementResponse
+import uk.gov.hmrc.http.HeaderCarrier
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class GetMovementService @Inject()(getMovementConnector: GetMovementConnector,
+                                   getPackagingTypesService: GetPackagingTypesService,
+                                   getCnCodeInformationService: GetCnCodeInformationService)(implicit ec: ExecutionContext) {
+
+  def getMovement(ern: String, arc: String)(implicit hc: HeaderCarrier): Future[GetMovementResponse] =
+    getMovementConnector.getMovement(ern, arc).flatMap {
+      case Right(movement) =>
+        for {
+          itemsWithPackaging <- getPackagingTypesService.getMovementItemsWithPackagingTypes(movement.items)
+          itemsWithCnCodeInfo <- getCnCodeInformationService.getCnCodeInformation(itemsWithPackaging)
+          itemsWithPackagingAndCnCodeInfo = itemsWithCnCodeInfo.map {
+            case (item, cnCodeInfo) => item.copy(unitOfMeasure = Some(cnCodeInfo.unitOfMeasure))
+          }
+        } yield movement.copy(items = itemsWithPackagingAndCnCodeInfo)
+
+      case Left(errorResponse) =>
+        throw MovementException(s"Failed to retrieve movement from emcs-tfe: $errorResponse")
+    }
+}

--- a/app/services/GetMovementService.scala
+++ b/app/services/GetMovementService.scala
@@ -18,7 +18,7 @@ package services
 
 import connectors.emcsTfe.GetMovementConnector
 import models.response.MovementException
-import uk.gov.hmrc.emcstfefrontend.models.response.emcsTfe.GetMovementResponse
+import models.response.emcsTfe.GetMovementResponse
 import uk.gov.hmrc.http.HeaderCarrier
 
 import javax.inject.{Inject, Singleton}

--- a/app/services/GetPackagingTypesService.scala
+++ b/app/services/GetPackagingTypesService.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services
+
+import connectors.referenceData.GetItemPackagingTypesConnector
+import models.response.PackagingTypesException
+import models.response.emcsTfe.MovementItem
+import models.response.referenceData.ItemPackaging
+import uk.gov.hmrc.http.HeaderCarrier
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class GetPackagingTypesService @Inject()(connector: GetItemPackagingTypesConnector)
+                                        (implicit ec: ExecutionContext) {
+
+  def getMovementItemsWithPackagingTypes(items: Seq[MovementItem])(implicit hc: HeaderCarrier): Future[Seq[MovementItem]] = {
+    connector.getItemPackagingTypes.map {
+      case Right(response) => matchItemsWithReferenceDataValues(response, items)
+      case Left(errorResponse) => throw PackagingTypesException(s"Failed to retrieve packaging types from emcs-tfe-reference-data: $errorResponse")
+    }
+  }
+
+  private def matchItemsWithReferenceDataValues(response: Seq[ItemPackaging], items: Seq[MovementItem]): Seq[MovementItem] =
+    items.map { item =>
+      item.copy(packaging = item.packaging.collect {
+        case packaging =>
+          response.find(_.packagingType == packaging.typeOfPackage) match {
+            case Some(value) =>
+              packaging.copy(typeOfPackage = value.description)
+            case None =>
+              throw PackagingTypesException(s"Failed to match item with packaging type from emcs-tfe-reference-data: $item")
+          }
+      })
+    }
+}

--- a/app/viewmodels/helpers/ViewMovementHelper.scala
+++ b/app/viewmodels/helpers/ViewMovementHelper.scala
@@ -16,11 +16,10 @@
 
 package viewmodels.helpers
 
-import models.common.RoleType
+import models.common.{AddressModel, RoleType}
 import models.common.RoleType.{GBRC, GBWK, XIRC, XIWK}
 import models.movementScenario.MovementScenario
 import models.movementScenario.MovementScenario._
-import models.common.AddressModel
 import models.requests.DataRequest
 import models.response.emcsTfe.GetMovementResponse
 import models.response.{InvalidUserTypeException, MissingDispatchPlaceTraderException}
@@ -32,8 +31,6 @@ import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.{Key, SummaryListR
 import utils.ExpectedDateOfArrival
 import viewmodels._
 import views.html.components.{list, p}
-import viewmodels.{Items, Overview, SubNavigationTab}
-import views.html.components.list
 import views.html.viewMovement.partials.overview_partial
 
 import javax.inject.Inject
@@ -62,14 +59,14 @@ class ViewMovementHelper @Inject()(
     classes = "govuk-summary-list__row"
   )
 
-  private[helpers] def summaryListRowBuilder(key: String, value: HtmlContent)(implicit messages: Messages) = SummaryListRow(
+  private[helpers] def summaryListRowBuilder(key: String, value: Html)(implicit messages: Messages) = SummaryListRow(
     key = Key(Text(value = messages(key))),
-    value = Value(value),
+    value = Value(HtmlContent(value)),
     classes = "govuk-summary-list__row"
   )
 
   private[helpers] def constructMovementOverview(movementResponse: GetMovementResponse)
-                                                (implicit messages: Messages): HtmlContent = {
+                                                (implicit messages: Messages): Html = {
 
     val localReferenceNumber = summaryListRowBuilder("viewMovement.overview.lrn", movementResponse.localReferenceNumber)
 
@@ -115,7 +112,7 @@ class ViewMovementHelper @Inject()(
   }
 
   private[helpers] def constructMovementView(movementResponse: GetMovementResponse)
-                                            (implicit request: DataRequest[_], messages: Messages): HtmlContent = {
+                                            (implicit request: DataRequest[_], messages: Messages): Html = {
 
 
     val userRole = RoleType.fromExciseRegistrationNumber(request.ern)
@@ -128,12 +125,12 @@ class ViewMovementHelper @Inject()(
 
     //Summary section - start
     val localReferenceNumber = summaryListRowBuilder("viewMovement.movement.summary.lrn", movementResponse.localReferenceNumber)
-    val eadStatus = if (movementResponse.eadStatus.equalsIgnoreCase("None")) None else Some(summaryListRowBuilder("viewMovement.movement.summary.eADStatus", HtmlContent(
+    val eadStatus = if (movementResponse.eadStatus.equalsIgnoreCase("None")) None else Some(summaryListRowBuilder("viewMovement.movement.summary.eADStatus",
       HtmlFormat.fill(Seq(
         p()(Text(movementResponse.eadStatus).asHtml),
         p(classes = "govuk-hint govuk-!-margin-top-0")(Text(eadStatusExplanation).asHtml)
       )
-    ))))
+    )))
     val receiptStatus = optReceiptStatusMessage.map(statusMessage => summaryListRowBuilder("viewMovement.movement.summary.receiptStatus", statusMessage))
     val movementType = summaryListRowBuilder("viewMovement.movement.summary.type", movementTypeValue)
     val movementDirection = summaryListRowBuilder("viewMovement.movement.summary.direction", if(userRole.isConsignor) "viewMovement.movement.summary.direction.out" else "viewMovement.movement.summary.direction.in")
@@ -218,7 +215,7 @@ class ViewMovementHelper @Inject()(
     }
   }
 
-private[helpers] def constructMovementDelivery(movementResponse: GetMovementResponse)(implicit messages: Messages): HtmlContent = {
+private[helpers] def constructMovementDelivery(movementResponse: GetMovementResponse)(implicit messages: Messages): Html = {
   val consignorSummaryCards = Seq(
     summaryListRowBuilder("viewMovement.delivery.consignor.name", movementResponse.consignorTrader.traderName),
     summaryListRowBuilder("viewMovement.delivery.consignor.ern", movementResponse.consignorTrader.traderExciseNumber),

--- a/app/viewmodels/helpers/ViewMovementHelper.scala
+++ b/app/viewmodels/helpers/ViewMovementHelper.scala
@@ -32,6 +32,8 @@ import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.{Key, SummaryListR
 import utils.ExpectedDateOfArrival
 import viewmodels._
 import views.html.components.{list, p}
+import viewmodels.{Items, Overview, SubNavigationTab}
+import views.html.components.list
 import views.html.viewMovement.partials.overview_partial
 
 import javax.inject.Inject
@@ -40,16 +42,18 @@ class ViewMovementHelper @Inject()(
                                     list: list,
                                     p: p,
                                     overviewPartial: overview_partial,
+                                    viewMovementItemsHelper: ViewMovementItemsHelper
                                   ) extends ExpectedDateOfArrival {
 
   def movementCard(subNavigationTab: SubNavigationTab, movementResponse: GetMovementResponse)
-                  (implicit request: DataRequest[_], messages: Messages): HtmlContent =
+                  (implicit request: DataRequest[_], messages: Messages): Html =
 
     subNavigationTab match {
       case Overview => constructMovementOverview(movementResponse)
       case Movement => constructMovementView(movementResponse)
       case Delivery => constructMovementDelivery(movementResponse)
-      case _ => HtmlContent("")
+      case Items    => viewMovementItemsHelper.constructMovementItems(movementResponse)
+      case _ => Html("")
     }
 
   private[helpers] def summaryListRowBuilder(key: String, value: String)(implicit messages: Messages) = SummaryListRow(
@@ -94,8 +98,7 @@ class ViewMovementHelper @Inject()(
       )
     }
 
-    HtmlContent(
-      overviewPartial(
+    overviewPartial(
         headingMessageKey = Some("viewMovement.overview.title"),
         cardTitleMessageKey = "viewMovement.overview.title",
         summaryListRows = Seq(
@@ -108,7 +111,6 @@ class ViewMovementHelper @Inject()(
           transportingVehicles
         )
       )
-    )
 
   }
 
@@ -149,8 +151,7 @@ class ViewMovementHelper @Inject()(
     //Invoice section - end
 
 
-    HtmlContent(
-      HtmlFormat.fill(
+    HtmlFormat.fill(
         Seq(
           overviewPartial(
             headingMessageKey = Some("viewMovement.movement.title"),
@@ -182,7 +183,6 @@ class ViewMovementHelper @Inject()(
           )
         )
       )
-    )
   }
 
   private[helpers] def getDateOfArrivalRow(movementResponse: GetMovementResponse)(implicit messages: Messages) = {
@@ -249,8 +249,7 @@ private[helpers] def constructMovementDelivery(movementResponse: GetMovementResp
     )
   }
 
-  HtmlContent(
-    HtmlFormat.fill(Seq(
+  HtmlFormat.fill(Seq(
       overviewPartial(
         headingMessageKey = Some("viewMovement.delivery.title"),
         cardTitleMessageKey = "viewMovement.delivery.consignor",
@@ -278,10 +277,9 @@ private[helpers] def constructMovementDelivery(movementResponse: GetMovementResp
         )
       }.getOrElse(Html(""))
     ))
-  )
 }
 
-private[helpers] def renderAddress(address: AddressModel): HtmlContent = {
+private[helpers] def renderAddress(address: AddressModel): Html = {
   val firstLineOfAddress = (address.streetNumber, address.street) match {
     case (Some(propertyNumber), Some(street)) => Html(s"$propertyNumber $street <br>")
     case (Some(number), None) => Html(s"$number <br>")
@@ -290,13 +288,12 @@ private[helpers] def renderAddress(address: AddressModel): HtmlContent = {
   }
   val city = address.city.fold(Html(""))(city => Html(s"$city <br>"))
   val postCode = address.postcode.fold(Html(""))(postcode => Html(s"$postcode"))
-  HtmlContent(
+
     HtmlFormat.fill(Seq(
       firstLineOfAddress,
       city,
       postCode
     ))
-  )
 }
 
 }

--- a/app/viewmodels/helpers/ViewMovementItemsHelper.scala
+++ b/app/viewmodels/helpers/ViewMovementItemsHelper.scala
@@ -16,29 +16,32 @@
 
 package viewmodels.helpers
 
-import models.response.emcsTfe.MovementItem
+import models.response.emcsTfe.{GetMovementResponse, MovementItem}
 import play.api.i18n.Messages
-import play.twirl.api.Html
-import uk.gov.hmrc.emcstfefrontend.models.response.emcsTfe.GetMovementResponse
+import play.twirl.api.{Html, HtmlFormat}
 import uk.gov.hmrc.govukfrontend.views.html.components.GovukTable
 import uk.gov.hmrc.govukfrontend.views.viewmodels.content.{HtmlContent, Text}
 import uk.gov.hmrc.govukfrontend.views.viewmodels.table.{HeadCell, Table, TableRow}
 import utils.ExpectedDateOfArrival
 import viewmodels.govuk.TagFluency
-import views.html.components.{link, list}
+import views.html.components.{h2, link, list}
 
 import javax.inject.Inject
 
 class ViewMovementItemsHelper @Inject()(list: list,
                                         link: link,
+                                        h2: h2,
                                         govukTable: GovukTable,
                                        ) extends ExpectedDateOfArrival with TagFluency {
 
   def constructMovementItems(movement: GetMovementResponse)(implicit messages: Messages): Html = {
-    govukTable(Table(
-      firstCellIsHeader = true,
-      rows = dataRows(movement.items),
-      head = headerRow
+    HtmlFormat.fill(Seq(
+      h2(messages("viewMovement.items.h2")),
+      govukTable(Table(
+        firstCellIsHeader = true,
+        rows = dataRows(movement.items),
+        head = headerRow
+      ))
     ))
   }
 
@@ -83,11 +86,11 @@ class ViewMovementItemsHelper @Inject()(list: list,
             Html(pckg.typeOfPackage)
           )))
         )
-//        TODO: Add in as part of ETFE-2882 (dependent on ETFE-2864 & ETFE-2858)
-//        TableRow(
-//          content = HtmlContent(itemReceiptStatus),
-//          classes = "white-space-nowrap"
-//        )
+        //        TODO: Add in as part of ETFE-2882 (dependent on ETFE-2864 & ETFE-2858)
+        //        TableRow(
+        //          content = HtmlContent(itemReceiptStatus),
+        //          classes = "white-space-nowrap"
+        //        )
       )
     }
 }

--- a/app/viewmodels/helpers/ViewMovementItemsHelper.scala
+++ b/app/viewmodels/helpers/ViewMovementItemsHelper.scala
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package viewmodels.helpers
+
+import models.response.emcsTfe.MovementItem
+import play.api.i18n.Messages
+import play.twirl.api.Html
+import uk.gov.hmrc.emcstfefrontend.models.response.emcsTfe.GetMovementResponse
+import uk.gov.hmrc.govukfrontend.views.html.components.GovukTable
+import uk.gov.hmrc.govukfrontend.views.viewmodels.content.{HtmlContent, Text}
+import uk.gov.hmrc.govukfrontend.views.viewmodels.table.{HeadCell, Table, TableRow}
+import utils.ExpectedDateOfArrival
+import viewmodels.govuk.TagFluency
+import views.html.components.{link, list}
+
+import javax.inject.Inject
+
+class ViewMovementItemsHelper @Inject()(list: list,
+                                        link: link,
+                                        govukTable: GovukTable,
+                                       ) extends ExpectedDateOfArrival with TagFluency {
+
+  def constructMovementItems(movement: GetMovementResponse)(implicit messages: Messages): Html = {
+    govukTable(Table(
+      firstCellIsHeader = true,
+      rows = dataRows(movement.items),
+      head = headerRow
+    ))
+  }
+
+  private[viewmodels] def headerRow(implicit messages: Messages): Option[Seq[HeadCell]] = Some(Seq(
+    HeadCell(Text(messages("viewMovement.items.table.heading.item"))),
+    HeadCell(Text(messages("viewMovement.items.table.heading.description"))),
+    HeadCell(Text(messages("viewMovement.items.table.heading.quantity"))),
+    HeadCell(Text(messages("viewMovement.items.table.heading.packaging")))
+    //TODO: Add in 'Receipt' column as part of ETFE-2882 (dependent on ETFE-2864 & ETFE-2858)
+    // HeadCell(Text(messages("viewMovement.items.table.heading.receipt")))
+  ))
+
+  private[viewmodels] def dataRows(items: Seq[MovementItem])(implicit messages: Messages): Seq[Seq[TableRow]] =
+    items.sortBy(_.itemUniqueReference).map { item =>
+
+      //TODO: Work out the status of the item based on report of receipt global conclusion and its existence in the report of receipt.
+      //      ETFE-2882 raised for this (dependent on ETFE-2864 & ETFE-2858)
+      //
+      // val itemReceiptStatus = ???
+
+      Seq(
+        TableRow(
+          content = HtmlContent(link(
+            link = testOnly.controllers.routes.UnderConstructionController.onPageLoad().url,
+            messageKey = messages("viewMovement.items.table.row.item", item.itemUniqueReference)
+          )),
+          classes = "white-space-nowrap"
+        ),
+        TableRow(
+          content = Text(item.commercialDescription.getOrElse("")),
+          classes = "govuk-!-width-one-third"
+        ),
+        TableRow(
+          content = Text(messages(
+            "viewMovement.items.table.row.quantity",
+            item.quantity.toString(),
+            item.unitOfMeasure.map(_.toShortFormatMessage()).getOrElse("")
+          ))
+        ),
+        TableRow(
+          content = HtmlContent(list(item.packaging.map(pckg =>
+            Html(pckg.typeOfPackage)
+          )))
+        )
+//        TODO: Add in as part of ETFE-2882 (dependent on ETFE-2864 & ETFE-2858)
+//        TableRow(
+//          content = HtmlContent(itemReceiptStatus),
+//          classes = "white-space-nowrap"
+//        )
+      )
+    }
+}

--- a/app/views/viewMovement/ViewMovementPage.scala.html
+++ b/app/views/viewMovement/ViewMovementPage.scala.html
@@ -38,7 +38,7 @@
         isConsignor: Boolean,
         subNavigationTabs: Seq[SubNavigationTab],
         currentSubNavigationTab: SubNavigationTab,
-        movementTabBody: HtmlContent
+        movementTabBody: Html
 )(implicit request: DataRequest[_], messages: Messages)
 
 @layout(titleNoForm(arc, Some(currentSubNavigationTab.name)), maybeShowActiveTrader = maybeShowActiveTrader(request), fullWidthContent = true) {
@@ -49,7 +49,7 @@
 
     @subNavigation(subNavigationTabs, currentSubNavigationTab)
 
-    @{movementTabBody.asHtml}
+    @{movementTabBody}
 
     @if(currentSubNavigationTab == Overview) {
         <div class="govuk-grid-row">

--- a/conf/messages
+++ b/conf/messages
@@ -14,6 +14,15 @@ base.captionHiddenText = This section is
 
 common.arc = Administrative reference code
 
+unitOfMeasure.kilograms.short = kg
+unitOfMeasure.kilograms.long = kilograms
+unitOfMeasure.litres15.short = litres
+unitOfMeasure.litres15.long = litres (temperature of 15°C)
+unitOfMeasure.litres20.short = litres
+unitOfMeasure.litres20.long = litres (temperature of 20°C)
+unitOfMeasure.thousands.short = x1000
+unitOfMeasure.thousands.long = x1000 items
+
 # MOV02 - Links
 viewMovement.title = Movement details
 viewMovement.reportAReceipt = Submit report of receipt
@@ -114,6 +123,16 @@ viewMovement.delivery.placeOfDestination = Place of destination
 viewMovement.delivery.placeOfDestination.name = Business name
 viewMovement.delivery.placeOfDestination.ern = Excise registration number (ERN)
 viewMovement.delivery.placeOfDestination.address = Address
+
+# MOV02 - Items
+viewMovement.items.table.heading.item = Item
+viewMovement.items.table.heading.description = Commercial description
+viewMovement.items.table.heading.quantity = Quantity
+viewMovement.items.table.heading.packaging = Packaging
+viewMovement.items.table.heading.receipt = Receipt
+viewMovement.items.table.row.item = Item {0}
+viewMovement.items.table.row.quantity = {0} {1}
+viewMovement.items.receiptStatus.notReceipted = Not Receipted
 
 viewMovementList.title = Movements in
 viewMovementList.heading = Movements in

--- a/conf/messages
+++ b/conf/messages
@@ -125,6 +125,7 @@ viewMovement.delivery.placeOfDestination.ern = Excise registration number (ERN)
 viewMovement.delivery.placeOfDestination.address = Address
 
 # MOV02 - Items
+viewMovement.items.h2 = Item details
 viewMovement.items.table.heading.item = Item
 viewMovement.items.table.heading.description = Commercial description
 viewMovement.items.table.heading.quantity = Quantity

--- a/it/ViewMovementIntegrationSpec.scala
+++ b/it/ViewMovementIntegrationSpec.scala
@@ -42,6 +42,8 @@ class ViewMovementIntegrationSpec extends IntegrationBaseSpec
     def emcsTfeUri: String = s"/emcs-tfe/movement/$testErn/$testArc"
 
     def getTraderKnownFactsUri: String = s"/emcs-tfe-reference-data/oracle/trader-known-facts"
+    def getPackagingTypesUri: String = s"/emcs-tfe-reference-data/oracle/packaging-types"
+    def postCnCodeInformationUri: String = s"/emcs-tfe-reference-data/oracle/cn-code-information"
 
     def request(): WSRequest = {
       setupStubs()
@@ -84,6 +86,8 @@ class ViewMovementIntegrationSpec extends IntegrationBaseSpec
             AuthStub.authorised()
             DownstreamStub.onSuccess(DownstreamStub.GET, emcsTfeUri, Status.OK, getMovementResponseInputJson)
             DownstreamStub.onSuccess(DownstreamStub.GET, getTraderKnownFactsUri, Map("exciseRegistrationId" -> testErn), Status.OK, Json.toJson(testMinTraderKnownFacts))
+            DownstreamStub.onSuccess(DownstreamStub.POST, postCnCodeInformationUri, Status.OK, Json.toJson(testCnCodeResponse))
+            DownstreamStub.onSuccess(DownstreamStub.GET, getPackagingTypesUri, Status.OK, Json.toJson(testItemPackagingTypesJson))
           }
 
           val response: WSResponse = await(request().get())
@@ -106,6 +110,8 @@ class ViewMovementIntegrationSpec extends IntegrationBaseSpec
             AuthStub.authorised()
             DownstreamStub.onSuccess(DownstreamStub.GET, emcsTfeUri, Status.OK, emcsTfeResponseBody)
             DownstreamStub.onSuccess(DownstreamStub.GET, getTraderKnownFactsUri, Map("exciseRegistrationId" -> testErn), Status.OK, Json.toJson(testMinTraderKnownFacts))
+            DownstreamStub.onSuccess(DownstreamStub.POST, postCnCodeInformationUri, Status.OK, Json.toJson(testCnCodeResponse))
+            DownstreamStub.onSuccess(DownstreamStub.GET, getPackagingTypesUri, Status.OK, Json.toJson(testItemPackagingTypesJson))
           }
 
           val response: WSResponse = await(request().get())
@@ -120,6 +126,8 @@ class ViewMovementIntegrationSpec extends IntegrationBaseSpec
             AuthStub.authorised()
             DownstreamStub.onSuccess(DownstreamStub.GET, emcsTfeUri, Status.OK, emcsTfeResponseBody)
             DownstreamStub.onSuccess(DownstreamStub.GET, getTraderKnownFactsUri, Map("exciseRegistrationId" -> testErn), Status.OK, Json.toJson(testMinTraderKnownFacts))
+            DownstreamStub.onSuccess(DownstreamStub.POST, postCnCodeInformationUri, Status.OK, Json.toJson(testCnCodeResponse))
+            DownstreamStub.onSuccess(DownstreamStub.GET, getPackagingTypesUri, Status.OK, Json.toJson(testItemPackagingTypesJson))
           }
 
           val response: WSResponse = await(request().get())
@@ -140,6 +148,8 @@ class ViewMovementIntegrationSpec extends IntegrationBaseSpec
             AuthStub.authorised()
             DownstreamStub.onSuccess(DownstreamStub.GET, emcsTfeUri, Status.INTERNAL_SERVER_ERROR, emcsTfeResponseBody)
             DownstreamStub.onSuccess(DownstreamStub.GET, getTraderKnownFactsUri, Map("exciseRegistrationId" -> testErn), Status.OK, Json.toJson(testMinTraderKnownFacts))
+            DownstreamStub.onSuccess(DownstreamStub.POST, postCnCodeInformationUri, Status.OK, Json.toJson(testCnCodeResponse))
+            DownstreamStub.onSuccess(DownstreamStub.GET, getPackagingTypesUri, Status.OK, Json.toJson(testItemPackagingTypesJson))
           }
 
           val response: WSResponse = await(request().get())

--- a/it/connectors/GetCnCodeInformationConnectorISpec.scala
+++ b/it/connectors/GetCnCodeInformationConnectorISpec.scala
@@ -1,0 +1,97 @@
+package connectors
+
+import com.github.tomakehurst.wiremock.client.WireMock._
+import com.github.tomakehurst.wiremock.http.Fault
+import connectors.referenceData.GetCnCodeInformationConnector
+import models.common.UnitOfMeasure.Kilograms
+import models.requests.{CnCodeInformationItem, CnCodeInformationRequest}
+import models.response.referenceData.{CnCodeInformation, CnCodeInformationResponse}
+import models.response.{JsonValidationError, UnexpectedDownstreamResponseError}
+import play.api.http.Status.{INTERNAL_SERVER_ERROR, OK}
+import play.api.libs.json.{JsArray, Json}
+import support.IntegrationBaseSpec
+import uk.gov.hmrc.http.HeaderCarrier
+
+class GetCnCodeInformationConnectorISpec extends IntegrationBaseSpec {
+
+  implicit private lazy val hc: HeaderCarrier = HeaderCarrier()
+
+  private lazy val connector: GetCnCodeInformationConnector = app.injector.instanceOf[GetCnCodeInformationConnector]
+
+  ".getCnCodeInformation()" must {
+
+    val url = "/emcs-tfe-reference-data/oracle/cn-code-information"
+    val request = CnCodeInformationRequest(Seq(CnCodeInformationItem("T400", "24029000")))
+    val requestJson = Json.obj("items" -> Json.arr(
+      Json.obj(
+        "productCode" -> "T400",
+        "cnCode" -> "24029000"
+      )
+    ))
+
+    "return a response model when the server responds OK" in {
+
+      wireMockServer.stubFor(
+        post(urlEqualTo(url))
+          .withRequestBody(equalToJson(Json.stringify(requestJson)))
+          .willReturn(aResponse().withStatus(OK).withBody(Json.stringify(Json.obj(
+            "24029000" -> Json.obj(
+              "cnCode" -> "T400",
+              "cnCodeDescription" -> "Cigars, cheroots, cigarillos and cigarettes not containing tobacco",
+              "exciseProductCode" -> "24029000",
+              "exciseProductCodeDescription" -> "Fine-cut tobacco for the rolling of cigarettes",
+              "unitOfMeasureCode" -> 1
+            )
+          ))))
+      )
+
+      connector.getCnCodeInformation(request).futureValue mustBe Right(CnCodeInformationResponse(data = Map(
+        "24029000" -> CnCodeInformation(
+          cnCode = "T400",
+          cnCodeDescription = "Cigars, cheroots, cigarillos and cigarettes not containing tobacco",
+          exciseProductCode = "24029000",
+          exciseProductCodeDescription = "Fine-cut tobacco for the rolling of cigarettes",
+          unitOfMeasure = Kilograms
+        )
+      )))
+    }
+
+    "must fail when the server responds with any other status" in {
+
+      wireMockServer.stubFor(
+        post(urlEqualTo(url))
+          .withRequestBody(equalToJson(Json.stringify(requestJson)))
+          .willReturn(aResponse().withStatus(INTERNAL_SERVER_ERROR))
+      )
+
+      connector.getCnCodeInformation(request).futureValue mustBe Left(UnexpectedDownstreamResponseError)
+    }
+
+    "must fail when the server responds with a body that can't be parsed to the expected response model" in {
+
+      wireMockServer.stubFor(
+        post(urlEqualTo(url))
+          .withRequestBody(equalToJson(Json.stringify(requestJson)))
+          .willReturn(aResponse().withStatus(OK).withBody(Json.stringify(Json.obj(
+            "24029000" -> JsArray(Seq(Json.obj(
+              "cnCodeDescription" -> "Cigars, cheroots, cigarillos and cigarettes not containing tobacco",
+              "unitOfMeasureCode" -> 1
+            )))
+          ))))
+      )
+
+      connector.getCnCodeInformation(request).futureValue mustBe Left(JsonValidationError)
+    }
+
+    "must fail when the connection fails" in {
+
+      wireMockServer.stubFor(
+        post(urlEqualTo(url))
+          .withRequestBody(equalToJson(Json.stringify(Json.toJson(request))))
+          .willReturn(aResponse().withFault(Fault.RANDOM_DATA_THEN_CLOSE))
+      )
+
+      connector.getCnCodeInformation(request).futureValue mustBe Left(UnexpectedDownstreamResponseError)
+    }
+  }
+}

--- a/it/connectors/GetItemPackagingTypesConnectorISpec.scala
+++ b/it/connectors/GetItemPackagingTypesConnectorISpec.scala
@@ -1,0 +1,55 @@
+package connectors
+
+import com.github.tomakehurst.wiremock.client.WireMock.{aResponse, get, urlEqualTo}
+import com.github.tomakehurst.wiremock.http.Fault
+import connectors.referenceData.GetItemPackagingTypesConnector
+import fixtures.ItemFixtures
+import models.response.UnexpectedDownstreamResponseError
+import play.api.test.Helpers._
+import support.IntegrationBaseSpec
+import uk.gov.hmrc.http.HeaderCarrier
+
+class GetItemPackagingTypesConnectorISpec extends IntegrationBaseSpec with ItemFixtures {
+
+  implicit private lazy val hc: HeaderCarrier = HeaderCarrier()
+
+  def url = s"/emcs-tfe-reference-data/oracle/packaging-types"
+
+  ".getItemPackagingTypes" must {
+
+    lazy val connector: GetItemPackagingTypesConnector = app.injector.instanceOf[GetItemPackagingTypesConnector]
+
+    s"return Right(Seq[ItemPackaging]) when the server responds OK" in {
+
+      wireMockServer.stubFor(
+        get(urlEqualTo(url))
+          .willReturn(
+            aResponse()
+              .withStatus(OK)
+              .withBody(testItemPackagingTypesJson.toString()))
+      )
+
+      connector.getItemPackagingTypes.futureValue mustBe Right(testItemPackagingTypes)
+    }
+
+    "must fail when the server responds with any other status" in {
+
+      wireMockServer.stubFor(
+        get(urlEqualTo(url))
+          .willReturn(aResponse().withStatus(INTERNAL_SERVER_ERROR))
+      )
+
+      connector.getItemPackagingTypes.futureValue mustBe Left(UnexpectedDownstreamResponseError)
+    }
+
+    "must fail when the connection fails" in {
+
+      wireMockServer.stubFor(
+        get(urlEqualTo(url))
+          .willReturn(aResponse().withFault(Fault.RANDOM_DATA_THEN_CLOSE))
+      )
+
+      connector.getItemPackagingTypes.futureValue mustBe Left(UnexpectedDownstreamResponseError)
+    }
+  }
+}

--- a/it/support/IntegrationBaseSpec.scala
+++ b/it/support/IntegrationBaseSpec.scala
@@ -17,6 +17,7 @@
 package support
 
 import base.SpecBase
+import org.scalatest.concurrent.IntegrationPatience
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.http.HeaderNames
@@ -28,7 +29,7 @@ import play.api.{Application, Environment, Mode}
 import scala.concurrent.ExecutionContext
 
 trait IntegrationBaseSpec extends SessionCookieBaker with SpecBase with WireMockHelper with GuiceOneServerPerSuite
-  with BeforeAndAfterEach with BeforeAndAfterAll {
+  with BeforeAndAfterEach with BeforeAndAfterAll with IntegrationPatience {
 
   implicit lazy val ec: ExecutionContext = app.injector.instanceOf[ExecutionContext]
 

--- a/test-utils/fixtures/GetMovementResponseFixtures.scala
+++ b/test-utils/fixtures/GetMovementResponseFixtures.scala
@@ -25,7 +25,7 @@ import play.api.libs.json.{JsValue, Json}
 
 import java.time.LocalDate
 
-trait GetMovementResponseFixtures {
+trait GetMovementResponseFixtures extends ItemFixtures {
   _: BaseFixtures =>
 
   val eadEsadModel: EadEsadModel = EadEsadModel(
@@ -145,7 +145,8 @@ trait GetMovementResponseFixtures {
           UnsatisfactoryModel(Shortage, None),
         )
       ))
-    ))
+    )),
+    items = Seq(item1, item2)
   )
 
   val getMovementResponseInputJson: JsValue = Json.obj(
@@ -273,6 +274,10 @@ trait GetMovementResponseFixtures {
         )
       ),
       "otherInformation" -> "some great reason"
+    ),
+    "items" -> Json.arr(
+      item1Json,
+      item2Json
     )
   )
 }

--- a/test-utils/fixtures/ItemFixtures.scala
+++ b/test-utils/fixtures/ItemFixtures.scala
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fixtures
+
+import models.common.UnitOfMeasure.Kilograms
+import models.response.emcsTfe.{MovementItem, Packaging}
+import models.response.referenceData.ItemPackaging
+import play.api.libs.json.{JsObject, Json}
+
+trait ItemFixtures { _: BaseFixtures =>
+
+  val testItemPackagingTypes: Seq[ItemPackaging] = Seq(
+    ItemPackaging("AE", "Aerosol"),
+    ItemPackaging("AM", "Ampoule, non protected"),
+    ItemPackaging("BG", "Bag"),
+    ItemPackaging("VA", "Vat")
+  )
+
+  val testItemPackagingTypesJson: JsObject = Json.obj(
+    "AE" -> "Aerosol",
+    "AM" -> "Ampoule, non protected",
+    "BG" -> "Bag",
+    "VA" -> "Vat"
+  )
+
+  val item1 = MovementItem(
+    itemUniqueReference = 1,
+    productCode = "W200",
+    cnCode = "22041011",
+    quantity = BigDecimal(500),
+    commercialDescription = Some("description 1"),
+    packaging = Seq(Packaging("AE", Some(1))),
+    unitOfMeasure = None
+  )
+
+  val item1Json = Json.obj(
+    "itemUniqueReference" -> 1,
+    "productCode" -> "W200",
+    "cnCode" -> "22041011",
+    "quantity" -> BigDecimal(500),
+    "commercialDescription" -> "description 1",
+    "packaging" -> Json.arr(
+      Json.obj(
+        "typeOfPackage" -> "AE",
+        "quantity" -> 1
+      )
+    ),
+    "unitOfMeasure" -> None
+  )
+
+  val item1WithPackaging = item1.copy(
+    packaging = Seq(Packaging("Aerosol", Some(1)))
+  )
+
+  val item1WithPackagingAndUnitOfMeasure = item1WithPackaging.copy(
+    unitOfMeasure = Some(Kilograms)
+  )
+
+  val item2 = MovementItem(
+    itemUniqueReference = 2,
+    productCode = "W300",
+    cnCode = "22041011",
+    quantity = BigDecimal(550),
+    commercialDescription = Some("description 2"),
+    packaging = Seq(
+      Packaging("AE", Some(1)),
+      Packaging("BG", Some(1))
+    ),
+    unitOfMeasure = None
+  )
+
+  val item2Json = Json.obj(
+    "itemUniqueReference" -> 2,
+    "productCode" -> "W300",
+    "cnCode" -> "22041011",
+    "quantity" -> BigDecimal(550),
+    "commercialDescription" -> "description 2",
+    "packaging" -> Json.arr(
+      Json.obj(
+        "typeOfPackage" -> "AE",
+        "quantity" -> 1
+      ),
+      Json.obj(
+        "typeOfPackage" -> "BG",
+        "quantity" -> 1
+      )
+    )
+  )
+
+  val item2WithPackaging = item2.copy(
+    packaging = Seq(
+      Packaging("Aerosol", Some(1)),
+      Packaging("Bag", Some(1))
+    )
+  )
+
+  val item2WithPackagingAndUnitOfMeasure = item2WithPackaging.copy(
+    unitOfMeasure = Some(Kilograms)
+  )
+}

--- a/test-utils/fixtures/ItemFixtures.scala
+++ b/test-utils/fixtures/ItemFixtures.scala
@@ -111,4 +111,21 @@ trait ItemFixtures { _: BaseFixtures =>
   val item2WithPackagingAndUnitOfMeasure = item2WithPackaging.copy(
     unitOfMeasure = Some(Kilograms)
   )
+
+  val testCnCodeResponse = Json.obj(
+    "22041011" -> Json.obj(
+      "cnCode" -> "22041011",
+        "cnCodeDescription" -> "Wine sparkling",
+        "exciseProductCode" -> "W300",
+        "exciseProductCodeDescription" -> "Wine",
+        "unitOfMeasureCode" -> 3
+    ),
+    "22041011" -> Json.obj(
+      "cnCode" -> "22041011",
+      "cnCodeDescription" -> "Wine sparkling",
+      "exciseProductCode" -> "W200",
+      "exciseProductCodeDescription" -> "Wine",
+      "unitOfMeasureCode" -> 3
+    )
+  )
 }

--- a/test-utils/fixtures/messages/UnitOfMeasureMessages.scala
+++ b/test-utils/fixtures/messages/UnitOfMeasureMessages.scala
@@ -14,15 +14,20 @@
  * limitations under the License.
  */
 
-package models.common
+package fixtures.messages
 
-import play.api.libs.json.{Json, Reads}
+object UnitOfMeasureMessages {
 
-case class AddressModel(streetNumber: Option[String],
-                        street: Option[String],
-                        postcode: Option[String],
-                        city: Option[String])
+  sealed trait ViewMessages { _: i18n =>
+    val kilogramsShort: String = "kg"
+    val kilogramsLong: String = "kilograms"
+    val litres20Short: String = "litres"
+    val litres20Long: String = "litres (temperature of 20°C)"
+    val litres15Short: String = "litres"
+    val litres15Long: String = "litres (temperature of 15°C)"
+    val thousandsShort: String = "x1000"
+    val thousandsLong: String = "x1000 items"
+  }
 
-object AddressModel {
-  implicit val reads: Reads[AddressModel] = Json.reads
+  object English extends ViewMessages with BaseEnglish
 }

--- a/test-utils/fixtures/messages/ViewMovementMessages.scala
+++ b/test-utils/fixtures/messages/ViewMovementMessages.scala
@@ -34,6 +34,7 @@ object ViewMovementMessages {
     val overviewCardNumberOfItems = "Number of items"
     val overviewCardTransporting = "Transporting vehicle(s)"
 
+    val itemsH2 = "Item details"
     val itemsTableItemHeading = "Item"
     val itemsTableCommercialDescriptionHeading = "Commercial description"
     val itemsTableQuantityHeading = "Quantity"

--- a/test-utils/fixtures/messages/ViewMovementMessages.scala
+++ b/test-utils/fixtures/messages/ViewMovementMessages.scala
@@ -34,6 +34,15 @@ object ViewMovementMessages {
     val overviewCardNumberOfItems = "Number of items"
     val overviewCardTransporting = "Transporting vehicle(s)"
 
+    val itemsTableItemHeading = "Item"
+    val itemsTableCommercialDescriptionHeading = "Commercial description"
+    val itemsTableQuantityHeading = "Quantity"
+    val itemsTablePackagingHeading = "Packaging"
+    val itemsTableReceiptHeading = "Receipt"
+
+    val itemsTableItemRow: Int => String = "Item " + _
+    val itemsReceiptStatusNotReceipted = "Not Receipted"
+
     val actionLinkSubmitReportOfReceipt = "Submit report of receipt"
     val actionLinkExplainDelay = "Explain a delay"
     val actionLinkExplainShortageOrExcess = "Explain a shortage or excess"

--- a/test/connectors/referenceData/CnCodeInformationHttpParserSpec.scala
+++ b/test/connectors/referenceData/CnCodeInformationHttpParserSpec.scala
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors.referenceData
+
+import base.SpecBase
+import mocks.connectors.MockHttpClient
+import models.common.UnitOfMeasure.Kilograms
+import models.response.referenceData.{CnCodeInformation, CnCodeInformationResponse}
+import models.response.{JsonValidationError, UnexpectedDownstreamResponseError}
+import play.api.http.{HeaderNames, MimeTypes, Status}
+import play.api.libs.json.Json
+import uk.gov.hmrc.http.{HttpClient, HttpResponse}
+
+class CnCodeInformationHttpParserSpec extends SpecBase
+  with Status with MimeTypes with HeaderNames with MockHttpClient {
+
+  lazy val httpParser = new CnCodeInformationHttpParser {
+    override def http: HttpClient = mockHttpClient
+  }
+
+  "CnCodeInformationReads.read(method: String, url: String, response: HttpResponse)" should {
+
+    "return a successful response" when {
+
+      "valid JSON is returned that can be parsed to the model" in {
+
+        val cnCodeInformation = Map("24029000" -> CnCodeInformation(
+          cnCode = "T200",
+          cnCodeDescription = "Cigars, cheroots, cigarillos and cigarettes not containing tobacco",
+          exciseProductCode = "24029000",
+          exciseProductCodeDescription = "Fine-cut tobacco for the rolling of cigarettes",
+          unitOfMeasure = Kilograms
+        ))
+
+        val cnCodeInformationJson = Json.obj("24029000" -> Json.obj(
+          "cnCode" -> "T200",
+          "cnCodeDescription" -> "Cigars, cheroots, cigarillos and cigarettes not containing tobacco",
+          "exciseProductCode" -> "24029000",
+          "exciseProductCodeDescription" -> "Fine-cut tobacco for the rolling of cigarettes",
+          "unitOfMeasureCode" -> 1
+        ))
+
+        val httpResponse = HttpResponse(Status.OK, cnCodeInformationJson, Map())
+
+        httpParser.CnCodeInformationReads.read("POST", "/oracle/cn-code-information", httpResponse) mustBe Right(
+          CnCodeInformationResponse(cnCodeInformation)
+        )
+      }
+    }
+
+    "return UnexpectedDownstreamError" when {
+
+      s"status is not OK (${Status.OK})" in {
+
+        val httpResponse = HttpResponse(Status.INTERNAL_SERVER_ERROR, Json.obj(), Map())
+
+        httpParser.CnCodeInformationReads.read("POST", "/oracle/cn-code-information", httpResponse) mustBe Left(UnexpectedDownstreamResponseError)
+      }
+    }
+
+    "return JsonValidationError" when {
+
+      s"response does not contain Json" in {
+
+        val httpResponse = HttpResponse(Status.OK, "", Map())
+
+        httpParser.CnCodeInformationReads.read("POST", "/oracle/cn-code-information", httpResponse) mustBe Left(JsonValidationError)
+      }
+
+      s"response contains JSON but can't be deserialized to model" in {
+
+        val httpResponse = HttpResponse(Status.OK, Json.arr(), Map())
+
+        httpParser.CnCodeInformationReads.read("POST", "/oracle/cn-code-information", httpResponse) mustBe Left(JsonValidationError)
+      }
+    }
+  }
+}

--- a/test/connectors/referenceData/GetItemPackagingTypesHttpParserSpec.scala
+++ b/test/connectors/referenceData/GetItemPackagingTypesHttpParserSpec.scala
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors.referenceData
+
+import base.SpecBase
+import fixtures.ItemFixtures
+import mocks.connectors.MockHttpClient
+import models.response.{JsonValidationError, UnexpectedDownstreamResponseError}
+import play.api.http.Status
+import play.api.libs.json.Json
+import uk.gov.hmrc.http.{HttpClient, HttpResponse}
+
+class GetItemPackagingTypesHttpParserSpec extends SpecBase with GetItemPackagingTypesHttpParser with MockHttpClient with ItemFixtures {
+
+  override def http: HttpClient = mockHttpClient
+
+  "GetItemPackagingTypesReads" should {
+
+    "return a Seq[ItemPackaging]" when {
+
+      s"an OK (${Status.OK}) response is retrieved" in {
+
+        val expectedResult = Right(testItemPackagingTypes)
+
+        val actualResult = new GetItemPackagingTypesReads().read("", "", HttpResponse(Status.OK, testItemPackagingTypesJson.toString()))
+
+        actualResult mustBe expectedResult
+      }
+    }
+
+    "return a JsonValidationError" when {
+
+      s"invalid json response is retrieved" in {
+
+        val expectedResult = Left(JsonValidationError)
+
+        val jsonResponse = Json.arr(
+          Json.obj("something" -> "that"),
+          Json.obj("is" -> "incorrect")
+        )
+
+        val actualResult = new GetItemPackagingTypesReads().read("", "", HttpResponse(Status.OK, jsonResponse.toString()))
+
+        actualResult mustBe expectedResult
+      }
+    }
+
+    "return UnexpectedDownstreamError" when {
+
+      s"status is anything else" in {
+
+        val expectedResult = Left(UnexpectedDownstreamResponseError)
+
+        val actualResult = new GetItemPackagingTypesReads().read("", "", HttpResponse(Status.INTERNAL_SERVER_ERROR, ""))
+
+        actualResult mustBe expectedResult
+      }
+    }
+  }
+}

--- a/test/mocks/connectors/MockEmcsTfeConnector.scala
+++ b/test/mocks/connectors/MockEmcsTfeConnector.scala
@@ -30,9 +30,9 @@ trait MockEmcsTfeConnector extends MockFactory {
   lazy val mockGetMovementListConnector: GetMovementListConnector = mock[GetMovementListConnector]
 
   object MockEmcsTfeConnector {
-    def getMovement(): CallHandler4[String, String, HeaderCarrier, ExecutionContext, Future[Either[ErrorResponse, GetMovementResponse]]] = {
+    def getMovement(ern: String, arc: String): CallHandler4[String, String, HeaderCarrier, ExecutionContext, Future[Either[ErrorResponse, GetMovementResponse]]] = {
       (mockGetMovementConnector.getMovement(_: String, _: String)(_: HeaderCarrier, _: ExecutionContext))
-        .expects(*, *, *, *)
+        .expects(ern, arc, *, *)
     }
 
     def getMovementList(ern: String): CallHandler3[String, HeaderCarrier, ExecutionContext, Future[Either[ErrorResponse, GetMovementListResponse]]] =

--- a/test/mocks/connectors/MockGetCnCodeInformationConnector.scala
+++ b/test/mocks/connectors/MockGetCnCodeInformationConnector.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mocks.connectors
+
+import connectors.referenceData.GetCnCodeInformationConnector
+import models.requests.CnCodeInformationRequest
+import models.response.ErrorResponse
+import models.response.referenceData.CnCodeInformationResponse
+import org.scalamock.handlers.CallHandler3
+import org.scalamock.scalatest.MockFactory
+import uk.gov.hmrc.http.HeaderCarrier
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait MockGetCnCodeInformationConnector extends MockFactory {
+
+  lazy val mockGetCnCodeInformationConnector: GetCnCodeInformationConnector = mock[GetCnCodeInformationConnector]
+
+  object MockGetCnCodeInformationConnector {
+    def getCnCodeInformation(request: CnCodeInformationRequest): CallHandler3[CnCodeInformationRequest, HeaderCarrier, ExecutionContext, Future[Either[ErrorResponse, CnCodeInformationResponse]]] =
+      (mockGetCnCodeInformationConnector.getCnCodeInformation(_: CnCodeInformationRequest)(_: HeaderCarrier, _: ExecutionContext))
+        .expects(request, *, *)
+  }
+}

--- a/test/mocks/connectors/MockGetItemPackagingTypesConnector.scala
+++ b/test/mocks/connectors/MockGetItemPackagingTypesConnector.scala
@@ -19,7 +19,7 @@ package mocks.connectors
 import connectors.referenceData.GetItemPackagingTypesConnector
 import models.response.ErrorResponse
 import models.response.referenceData.ItemPackaging
-import org.scalamock.handlers.{CallHandler2, CallHandler3}
+import org.scalamock.handlers.CallHandler2
 import org.scalamock.scalatest.MockFactory
 import uk.gov.hmrc.http.HeaderCarrier
 

--- a/test/mocks/connectors/MockGetItemPackagingTypesConnector.scala
+++ b/test/mocks/connectors/MockGetItemPackagingTypesConnector.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mocks.connectors
+
+import connectors.referenceData.GetItemPackagingTypesConnector
+import models.response.ErrorResponse
+import models.response.referenceData.ItemPackaging
+import org.scalamock.handlers.{CallHandler2, CallHandler3}
+import org.scalamock.scalatest.MockFactory
+import uk.gov.hmrc.http.HeaderCarrier
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait MockGetItemPackagingTypesConnector extends MockFactory {
+
+  lazy val mockGetItemPackagingTypesConnector: GetItemPackagingTypesConnector = mock[GetItemPackagingTypesConnector]
+
+  object MockGetItemPackagingTypesConnector {
+
+    def getItemPackagingTypes: CallHandler2[HeaderCarrier, ExecutionContext, Future[Either[ErrorResponse, Seq[ItemPackaging]]]] =
+      (mockGetItemPackagingTypesConnector.getItemPackagingTypes(_: HeaderCarrier, _: ExecutionContext)).expects(*, *)
+  }
+
+}

--- a/test/mocks/services/MockGetCnCodeInformationService.scala
+++ b/test/mocks/services/MockGetCnCodeInformationService.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mocks.services
+
+import models.response.emcsTfe.MovementItem
+import models.response.referenceData.CnCodeInformation
+import org.scalamock.handlers.CallHandler2
+import org.scalamock.scalatest.MockFactory
+import services.GetCnCodeInformationService
+import uk.gov.hmrc.http.HeaderCarrier
+
+import scala.concurrent.Future
+
+trait MockGetCnCodeInformationService extends MockFactory {
+
+  lazy val mockGetCnCodeInformationService: GetCnCodeInformationService = mock[GetCnCodeInformationService]
+
+  object MockGetCnCodeInformationService {
+    def getCnCodeInformation(items: Seq[MovementItem]): CallHandler2[Seq[MovementItem], HeaderCarrier, Future[Seq[(MovementItem, CnCodeInformation)]]] =
+      (mockGetCnCodeInformationService.getCnCodeInformation(_: Seq[MovementItem])(_: HeaderCarrier))
+        .expects(items, *)
+  }
+}

--- a/test/mocks/services/MockGetMovementService.scala
+++ b/test/mocks/services/MockGetMovementService.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mocks.services
+
+import org.scalamock.handlers.CallHandler3
+import org.scalamock.scalatest.MockFactory
+import services.GetMovementService
+import uk.gov.hmrc.emcstfefrontend.models.response.emcsTfe.GetMovementResponse
+import uk.gov.hmrc.http.HeaderCarrier
+
+import scala.concurrent.Future
+
+trait MockGetMovementService extends MockFactory {
+
+  lazy val mockGetMovementService: GetMovementService = mock[GetMovementService]
+
+  object MockGetMovementService {
+    def getMovement(ern: String, arc: String): CallHandler3[String, String, HeaderCarrier, Future[GetMovementResponse]] =
+      (mockGetMovementService.getMovement(_: String, _: String)(_: HeaderCarrier))
+        .expects(ern, arc, *)
+  }
+}

--- a/test/mocks/services/MockGetMovementService.scala
+++ b/test/mocks/services/MockGetMovementService.scala
@@ -16,10 +16,10 @@
 
 package mocks.services
 
+import models.response.emcsTfe.GetMovementResponse
 import org.scalamock.handlers.CallHandler3
 import org.scalamock.scalatest.MockFactory
 import services.GetMovementService
-import uk.gov.hmrc.emcstfefrontend.models.response.emcsTfe.GetMovementResponse
 import uk.gov.hmrc.http.HeaderCarrier
 
 import scala.concurrent.Future

--- a/test/mocks/services/MockGetPackagingTypesService.scala
+++ b/test/mocks/services/MockGetPackagingTypesService.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mocks.services
+
+import models.response.emcsTfe.MovementItem
+import org.scalamock.handlers.CallHandler2
+import org.scalamock.scalatest.MockFactory
+import services.GetPackagingTypesService
+import uk.gov.hmrc.http.HeaderCarrier
+
+import scala.concurrent.Future
+
+trait MockGetPackagingTypesService extends MockFactory {
+
+  lazy val mockGetPackagingTypesService: GetPackagingTypesService = mock[GetPackagingTypesService]
+
+  object MockGetPackagingTypesService {
+    def getMovementItemsWithPackagingTypes(items: Seq[MovementItem]): CallHandler2[Seq[MovementItem], HeaderCarrier, Future[Seq[MovementItem]]] =
+      (mockGetPackagingTypesService.getMovementItemsWithPackagingTypes(_: Seq[MovementItem])(_: HeaderCarrier))
+        .expects(items, *)
+  }
+}

--- a/test/models/GetMovementResponseSpec.scala
+++ b/test/models/GetMovementResponseSpec.scala
@@ -36,10 +36,6 @@ class GetMovementResponseSpec extends SpecBase with GetMovementResponseFixtures 
       Json.fromJson[GetMovementResponse](getMovementResponseInputJson) shouldBe JsSuccess(getMovementResponseModel)
     }
 
-    "write to json" in {
-      Json.toJson(getMovementResponseModel) shouldBe getMovementResponseInputJson
-    }
-
     ".formattedDateOfDispatch" in {
       getMovementResponseModel.formattedDateOfDispatch shouldBe "20 November 2008"
     }

--- a/test/models/common/UnitOfMeasureSpec.scala
+++ b/test/models/common/UnitOfMeasureSpec.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.common
+
+import base.SpecBase
+import UnitOfMeasure._
+import fixtures.messages.UnitOfMeasureMessages
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.i18n.Messages
+
+class UnitOfMeasureSpec extends SpecBase with GuiceOneAppPerSuite {
+
+  "UnitOfMeasure" must {
+
+    "be constructed from UnitOfMeasureCode for all valid codes" in {
+
+      UnitOfMeasure.apply(1) mustBe Kilograms
+      UnitOfMeasure.apply(2) mustBe Litres15
+      UnitOfMeasure.apply(3) mustBe Litres20
+      UnitOfMeasure.apply(4) mustBe Thousands
+    }
+
+    "throws illegal argument error when EPC can't be mapped to GoodsType" in {
+      intercept[IllegalArgumentException](UnitOfMeasure.apply(5)).getMessage mustBe
+        s"Invalid argument of '5' received which can not be mapped to a UnitOfMeasure"
+    }
+
+    Seq(UnitOfMeasureMessages.English).foreach { messagesForLanguage =>
+
+      s"when being rendered in lang code of '${messagesForLanguage.lang.code}'" must {
+
+        implicit val msgs: Messages = messages(Seq(messagesForLanguage.lang))
+
+        "output the correct messages" in {
+
+          Kilograms.toShortFormatMessage() mustBe messagesForLanguage.kilogramsShort
+          Kilograms.toLongFormatMessage() mustBe messagesForLanguage.kilogramsLong
+          Litres15.toShortFormatMessage() mustBe messagesForLanguage.litres15Short
+          Litres15.toLongFormatMessage() mustBe messagesForLanguage.litres15Long
+          Litres20.toShortFormatMessage() mustBe messagesForLanguage.litres20Short
+          Litres20.toLongFormatMessage() mustBe messagesForLanguage.litres20Long
+          Thousands.toShortFormatMessage() mustBe messagesForLanguage.thousandsShort
+          Thousands.toLongFormatMessage() mustBe messagesForLanguage.thousandsLong
+        }
+      }
+    }
+  }
+}

--- a/test/services/GetCnCodeInformationServiceSpec.scala
+++ b/test/services/GetCnCodeInformationServiceSpec.scala
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services
+
+import base.SpecBase
+import fixtures.ItemFixtures
+import mocks.connectors.MockGetCnCodeInformationConnector
+import models.common.UnitOfMeasure.Kilograms
+import models.requests.{CnCodeInformationItem, CnCodeInformationRequest}
+import models.response.{CnCodeInformationException, UnexpectedDownstreamResponseError}
+import models.response.referenceData.{CnCodeInformation, CnCodeInformationResponse}
+import uk.gov.hmrc.http.HeaderCarrier
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class GetCnCodeInformationServiceSpec extends SpecBase with ItemFixtures with MockGetCnCodeInformationConnector {
+
+  implicit val hc = HeaderCarrier()
+  implicit val ec = ExecutionContext.global
+
+  lazy val testService = new GetCnCodeInformationService(mockGetCnCodeInformationConnector)
+
+  val items = Seq(item1.copy(productCode = "T400", cnCode = "24029000"))
+  val request = CnCodeInformationRequest(CnCodeInformationItem(items))
+
+  ".getCnCodeInformationWithMovementItems" must {
+
+    "return Success response" when {
+
+      "Connector returns success from downstream" in {
+        MockGetCnCodeInformationConnector.getCnCodeInformation(request).returns(Future.successful(Right(CnCodeInformationResponse(data = Map(
+          "24029000" -> CnCodeInformation(
+            cnCode = "T400",
+            cnCodeDescription = "Cigars, cheroots, cigarillos and cigarettes not containing tobacco",
+            exciseProductCode = "24029000",
+            exciseProductCodeDescription = "Fine-cut tobacco for the rolling of cigarettes",
+            unitOfMeasure = Kilograms
+          )
+        )))))
+
+        testService.getCnCodeInformation(items)(hc).futureValue mustBe Seq((items.head, CnCodeInformation(
+          cnCode = "T400",
+          cnCodeDescription = "Cigars, cheroots, cigarillos and cigarettes not containing tobacco",
+          exciseProductCode = "24029000",
+          exciseProductCodeDescription = "Fine-cut tobacco for the rolling of cigarettes",
+          unitOfMeasure = Kilograms
+        )))
+      }
+    }
+
+    "return Failure response" when {
+
+      "Connector returns failure from downstream" in {
+
+        MockGetCnCodeInformationConnector.getCnCodeInformation(request).returns(Future.successful(Left(UnexpectedDownstreamResponseError)))
+
+        val result = intercept[CnCodeInformationException](await(testService.getCnCodeInformation(items)(hc)))
+
+        result.getMessage must include(s"Failed to retrieve CN Code information")
+      }
+
+      "not all items match something from the Connector" in {
+
+        val items = Seq(
+          item1.copy(productCode = "T400", cnCode = "24029000"),
+          item1.copy(productCode = "T401", cnCode = "24029001"),
+          item1.copy(productCode = "T402", cnCode = "24029002")
+        )
+        val request = CnCodeInformationRequest(CnCodeInformationItem(items))
+
+        MockGetCnCodeInformationConnector.getCnCodeInformation(request).returns(Future.successful(Right(CnCodeInformationResponse(data = Map(
+          "24029000" -> CnCodeInformation(
+            cnCode = "T400",
+            cnCodeDescription = "Cigars, cheroots, cigarillos and cigarettes not containing tobacco",
+            exciseProductCode = "24029000",
+            exciseProductCodeDescription = "Fine-cut tobacco for the rolling of cigarettes",
+            unitOfMeasure = Kilograms
+          ),
+          "24029001" -> CnCodeInformation(
+            cnCode = "T401",
+            cnCodeDescription = "Cigars, cheroots, cigarillos and cigarettes not containing tobacco",
+            exciseProductCode = "24029001",
+            exciseProductCodeDescription = "Fine-cut tobacco for the rolling of cigarettes",
+            unitOfMeasure = Kilograms
+          )
+        )))))
+
+        val result = intercept[CnCodeInformationException](await(testService.getCnCodeInformation(items)(hc)))
+
+        result.getMessage must include(s"Failed to match item with CN Code information")
+      }
+    }
+  }
+}

--- a/test/services/GetMovementServiceSpec.scala
+++ b/test/services/GetMovementServiceSpec.scala
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services
+
+import base.SpecBase
+import fixtures.GetMovementResponseFixtures
+import mocks.connectors.MockEmcsTfeConnector
+import mocks.services.{MockGetCnCodeInformationService, MockGetPackagingTypesService}
+import models.common.UnitOfMeasure.Kilograms
+import models.response.emcsTfe.MovementItem
+import models.response.referenceData.CnCodeInformation
+import models.response.{CnCodeInformationException, MovementException, PackagingTypesException, UnexpectedDownstreamResponseError}
+import uk.gov.hmrc.http.HeaderCarrier
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class GetMovementServiceSpec extends SpecBase
+  with MockEmcsTfeConnector
+  with MockGetPackagingTypesService
+  with MockGetCnCodeInformationService
+  with GetMovementResponseFixtures {
+
+  implicit val hc: HeaderCarrier = HeaderCarrier()
+  implicit val ec: ExecutionContext = ExecutionContext.global
+
+  lazy val testService = new GetMovementService(
+    getMovementConnector = mockGetMovementConnector,
+    getPackagingTypesService = mockGetPackagingTypesService,
+    getCnCodeInformationService = mockGetCnCodeInformationService
+  )
+
+  val movementItems: Seq[MovementItem] = Seq(item1, item2)
+  val movementItemsWithPackaging: Seq[MovementItem] = Seq(item1WithPackaging, item2WithPackaging)
+
+  ".getMovement" when {
+
+    "Connector returns success from downstream" when {
+
+      "Reference Data returns success for Packaging Types" when {
+
+        "Reference Data returns success for CnCodeInformation" must {
+
+          "return successful movement with the packaging and unit of measure added to the response" in {
+
+            MockEmcsTfeConnector.getMovement(testErn, testArc)
+              .returns(Future.successful(Right(getMovementResponseModel.copy(items = movementItems))))
+
+            MockGetPackagingTypesService.getMovementItemsWithPackagingTypes(movementItems)
+              .returns(Future.successful(movementItemsWithPackaging))
+
+            MockGetCnCodeInformationService.getCnCodeInformation(movementItemsWithPackaging)
+              .returns(Future.successful(Seq(
+                item1WithPackaging -> CnCodeInformation(
+                  cnCode = "T400",
+                  cnCodeDescription = "Cigars, cheroots, cigarillos and cigarettes not containing tobacco",
+                  exciseProductCode = "24029000",
+                  exciseProductCodeDescription = "Fine-cut tobacco for the rolling of cigarettes",
+                  unitOfMeasure = Kilograms
+                ),
+                item2WithPackaging -> CnCodeInformation(
+                  cnCode = "T400",
+                  cnCodeDescription = "Cigars, cheroots, cigarillos and cigarettes not containing tobacco",
+                  exciseProductCode = "24029000",
+                  exciseProductCodeDescription = "Fine-cut tobacco for the rolling of cigarettes",
+                  unitOfMeasure = Kilograms
+                )
+              )))
+
+            testService.getMovement(testErn, testArc)(hc).futureValue mustBe getMovementResponseModel.copy(items = Seq(
+              item1WithPackagingAndUnitOfMeasure,
+              item2WithPackagingAndUnitOfMeasure
+            ))
+          }
+        }
+
+        "Reference Data returns failure for CnCodeInformation" must {
+
+          "raise a CnCodeInformationException" in {
+
+            MockEmcsTfeConnector.getMovement(testErn, testArc)
+              .returns(Future.successful(Right(getMovementResponseModel.copy(items = movementItems))))
+
+            MockGetPackagingTypesService.getMovementItemsWithPackagingTypes(movementItems)
+              .returns(Future.successful(movementItemsWithPackaging))
+
+            MockGetCnCodeInformationService.getCnCodeInformation(movementItemsWithPackaging)
+              .returns(Future.failed(CnCodeInformationException("bang")))
+
+            val result = intercept[CnCodeInformationException](await(testService.getMovement(testErn, testArc)(hc)))
+
+            result.getMessage must include("bang")
+          }
+        }
+      }
+
+      "Reference Data returns failure for Package Types" must {
+
+        "raise a CnCodeInformationException" in {
+
+          MockEmcsTfeConnector.getMovement(testErn, testArc)
+            .returns(Future.successful(Right(getMovementResponseModel.copy(items = movementItems))))
+
+          MockGetPackagingTypesService.getMovementItemsWithPackagingTypes(movementItems)
+            .returns(Future.failed(PackagingTypesException("bang")))
+
+          val result = intercept[PackagingTypesException](await(testService.getMovement(testErn, testArc)(hc)))
+
+          result.getMessage must include("bang")
+        }
+      }
+    }
+
+    "Connector returns failure from downstream" must {
+
+      "raise a MovementException" in {
+
+        MockEmcsTfeConnector.getMovement(testErn, testArc)
+          .returns(Future.successful(Left(UnexpectedDownstreamResponseError)))
+
+        val result = intercept[MovementException](await(testService.getMovement(testErn, testArc)(hc)))
+
+        result.getMessage must include("Failed to retrieve movement from emcs-tfe")
+      }
+    }
+  }
+}

--- a/test/services/GetPackagingTypesServiceSpec.scala
+++ b/test/services/GetPackagingTypesServiceSpec.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services
+
+import base.SpecBase
+import fixtures.GetMovementResponseFixtures
+import mocks.connectors.MockGetItemPackagingTypesConnector
+import models.response.emcsTfe.MovementItem
+import models.response.referenceData.ItemPackaging
+import models.response.{PackagingTypesException, UnexpectedDownstreamResponseError}
+import uk.gov.hmrc.http.HeaderCarrier
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class GetPackagingTypesServiceSpec extends SpecBase with MockGetItemPackagingTypesConnector with GetMovementResponseFixtures {
+
+  implicit val hc: HeaderCarrier = HeaderCarrier()
+  implicit val ec: ExecutionContext = ExecutionContext.global
+
+  lazy val testService = new GetPackagingTypesService(mockGetItemPackagingTypesConnector)
+
+  val movementItems: Seq[MovementItem] = Seq(item1, item2)
+
+  ".getPackagingTypes" must {
+
+    "return Success response" when {
+
+      "Connector returns success from downstream" in {
+
+        MockGetItemPackagingTypesConnector.getItemPackagingTypes.returns(Future.successful(Right(
+          testItemPackagingTypes
+        )))
+
+        testService.getMovementItemsWithPackagingTypes(movementItems)(hc).futureValue mustBe Seq(
+          item1WithPackaging,
+          item2WithPackaging
+        )
+      }
+    }
+
+    "return Failure response" when {
+
+      "Connector returns failure from downstream" in {
+
+        MockGetItemPackagingTypesConnector.getItemPackagingTypes.returns(Future.successful(Left(UnexpectedDownstreamResponseError)))
+
+        val result = intercept[PackagingTypesException](await(testService.getMovementItemsWithPackagingTypes(movementItems)(hc)))
+
+        result.getMessage must include("Failed to retrieve packaging types from emcs-tfe-reference-data")
+      }
+
+      "not all items match something from the Connector" in {
+        MockGetItemPackagingTypesConnector.getItemPackagingTypes.returns(Future.successful(Right(
+          Seq(ItemPackaging("AE", "Aerosol"))
+        )))
+
+        val result = intercept[PackagingTypesException](await(testService.getMovementItemsWithPackagingTypes(movementItems)(hc)))
+
+        result.getMessage must include(s"Failed to match item with packaging type from emcs-tfe-reference-data")
+      }
+    }
+  }
+
+}

--- a/test/viewmodels/helpers/ViewMovementHelperSpec.scala
+++ b/test/viewmodels/helpers/ViewMovementHelperSpec.scala
@@ -27,6 +27,7 @@ import models.response.InvalidUserTypeException
 import org.jsoup.Jsoup
 import play.api.i18n.Messages
 import play.api.test.FakeRequest
+import play.twirl.api.Html
 import uk.gov.hmrc.govukfrontend.views.Aliases.{Key, SummaryListRow, Text, Value}
 import uk.gov.hmrc.govukfrontend.views.viewmodels.content.HtmlContent
 import views.BaseSelectors
@@ -51,7 +52,7 @@ class ViewMovementHelperSpec extends SpecBase with GetMovementResponseFixtures {
   "constructMovementOverview" should {
     "output the correct rows" in {
       val result = helper.constructMovementOverview(getMovementResponseModel)
-      val card = Jsoup.parse(result.asHtml.toString())
+      val card = Jsoup.parse(result.toString())
       card.select(Selectors.cardTitle).text() mustBe "Overview"
       card.select(Selectors.cardRowKey(1)).text() mustBe "Local Reference Number (LRN)"
       card.select(Selectors.cardRowValue(1)).text() mustBe testLrn
@@ -75,7 +76,7 @@ class ViewMovementHelperSpec extends SpecBase with GetMovementResponseFixtures {
 
       "the date of arrival is set" in {
         val result = helper.constructMovementView(getMovementResponseModel)
-        val card = Jsoup.parse(result.asHtml.toString())
+        val card = Jsoup.parse(result.toString())
         card.select(Selectors.cardAtIndexTitle(1)).text() mustBe "Summary"
         card.select(Selectors.cardAtIndexRowKey(1, 1)).text() mustBe "LRN"
         card.select(Selectors.cardAtIndexRowValue(1, 1)).text() mustBe testLrn
@@ -105,7 +106,7 @@ class ViewMovementHelperSpec extends SpecBase with GetMovementResponseFixtures {
 
       "the date of arrival is NOT set (calculating the predicted date of arrival) - not showing the receipt status" in {
         val result = helper.constructMovementView(getMovementResponseModel.copy(reportOfReceipt = None))
-        val card = Jsoup.parse(result.asHtml.toString())
+        val card = Jsoup.parse(result.toString())
         card.select(Selectors.cardAtIndexTitle(1)).text() mustBe "Summary"
         card.select(Selectors.cardAtIndexRowKey(1, 1)).text() mustBe "LRN"
         card.select(Selectors.cardAtIndexRowValue(1, 1)).text() mustBe testLrn
@@ -148,7 +149,7 @@ class ViewMovementHelperSpec extends SpecBase with GetMovementResponseFixtures {
 
         s"when the eAD status is ${statusToExplanation._1} - show the correct status and explanation" in {
           val result = helper.constructMovementView(getMovementResponseModel.copy(eadStatus = statusToExplanation._1))
-          val card = Jsoup.parse(result.asHtml.toString())
+          val card = Jsoup.parse(result.toString())
           if(statusToExplanation._1 == "None") {
             card.select(Selectors.cardAtIndexRowKey(1, 2)).text() mustBe "Receipt status"
           } else {
@@ -166,7 +167,7 @@ class ViewMovementHelperSpec extends SpecBase with GetMovementResponseFixtures {
 
       "consignor, place of dispatch, consignee and place of destination are present" in {
         val result = helper.constructMovementDelivery(getMovementResponseModel)
-        val card = Jsoup.parse(result.asHtml.toString())
+        val card = Jsoup.parse(result.toString())
         card.select(Selectors.cardAtIndexTitle(1)).text() mustBe "Consignor"
         card.select(Selectors.cardAtIndexRowKey(1, 1)).text() mustBe "Business name"
         card.select(Selectors.cardAtIndexRowValue(1, 1)).text() mustBe "Current 801 Consignor"
@@ -202,7 +203,7 @@ class ViewMovementHelperSpec extends SpecBase with GetMovementResponseFixtures {
 
       "consignor, consignee and place of destination are present" in {
         val result = helper.constructMovementDelivery(getMovementResponseModel.copy(placeOfDispatchTrader = None))
-        val card = Jsoup.parse(result.asHtml.toString())
+        val card = Jsoup.parse(result.toString())
         card.select(Selectors.cardAtIndexTitle(1)).text() mustBe "Consignor"
         card.select(Selectors.cardAtIndexRowKey(1, 1)).text() mustBe "Business name"
         card.select(Selectors.cardAtIndexRowValue(1, 1)).text() mustBe "Current 801 Consignor"
@@ -230,7 +231,7 @@ class ViewMovementHelperSpec extends SpecBase with GetMovementResponseFixtures {
 
       "consignor, place of dispatch and place of destination are present" in {
         val result = helper.constructMovementDelivery(getMovementResponseModel.copy(consigneeTrader = None))
-        val card = Jsoup.parse(result.asHtml.toString())
+        val card = Jsoup.parse(result.toString())
         card.select(Selectors.cardAtIndexTitle(1)).text() mustBe "Consignor"
         card.select(Selectors.cardAtIndexRowKey(1, 1)).text() mustBe "Business name"
         card.select(Selectors.cardAtIndexRowValue(1, 1)).text() mustBe "Current 801 Consignor"
@@ -258,7 +259,7 @@ class ViewMovementHelperSpec extends SpecBase with GetMovementResponseFixtures {
 
       "consignor, place of dispatch and consignee are present" in {
         val result = helper.constructMovementDelivery(getMovementResponseModel.copy(deliveryPlaceTrader = None))
-        val card = Jsoup.parse(result.asHtml.toString())
+        val card = Jsoup.parse(result.toString())
         card.select(Selectors.cardAtIndexTitle(1)).text() mustBe "Consignor"
         card.select(Selectors.cardAtIndexRowKey(1, 1)).text() mustBe "Business name"
         card.select(Selectors.cardAtIndexRowValue(1, 1)).text() mustBe "Current 801 Consignor"
@@ -297,10 +298,10 @@ class ViewMovementHelperSpec extends SpecBase with GetMovementResponseFixtures {
   }
 
   "construct a key value summary list row (when value is HTML)" in {
-    val result = helper.summaryListRowBuilder("random.key", HtmlContent("some html value"))
+    val result = helper.summaryListRowBuilder("random.key", Html("some html value"))
     result mustBe SummaryListRow(
       key = Key(Text(value = "random.key")),
-      value = Value(HtmlContent("some html value")),
+      value = Value(HtmlContent(Html("some html value"))),
       classes = "govuk-summary-list__row"
     )
   }
@@ -312,28 +313,28 @@ class ViewMovementHelperSpec extends SpecBase with GetMovementResponseFixtures {
       val addressModel: AddressModel = AddressModel(
         Some("1"), Some("Street Street"), Some("POST CODE"), Some("City City")
       )
-      helper.renderAddress(addressModel) mustBe HtmlContent("1 Street Street <br>City City <br>POST CODE")
+      helper.renderAddress(addressModel) mustBe Html("1 Street Street <br>City City <br>POST CODE")
     }
 
     "render just street when no street number provided" in {
       val addressModel: AddressModel = AddressModel(
         None, Some("Street Street"), Some("POST CODE"), Some("City City")
       )
-      helper.renderAddress(addressModel) mustBe HtmlContent("Street Street <br>City City <br>POST CODE")
+      helper.renderAddress(addressModel) mustBe Html("Street Street <br>City City <br>POST CODE")
     }
 
     "render nothing when all fields are undefined" in {
       val addressModel: AddressModel = AddressModel(
         None, None, None, None
       )
-      helper.renderAddress(addressModel) mustBe HtmlContent("")
+      helper.renderAddress(addressModel) mustBe Html("")
     }
 
     "render all rows when all fields are defined" in {
       val addressModel: AddressModel = AddressModel(
         Some("1"), Some("Street Street"), Some("POST CODE"), Some("City City")
       )
-      helper.renderAddress(addressModel) mustBe HtmlContent("1 Street Street <br>City City <br>POST CODE")
+      helper.renderAddress(addressModel) mustBe Html("1 Street Street <br>City City <br>POST CODE")
     }
   }
 
@@ -348,10 +349,10 @@ class ViewMovementHelperSpec extends SpecBase with GetMovementResponseFixtures {
     }
 
     "construct a key value summary list row (when value is HTML)" in {
-      val result = helper.summaryListRowBuilder("random.key", HtmlContent("some html value"))
+      val result = helper.summaryListRowBuilder("random.key", Html("some html value"))
       result mustBe SummaryListRow(
         key = Key(Text(value = "random.key")),
-        value = Value(HtmlContent("some html value")),
+        value = Value(HtmlContent(Html("some html value"))),
         classes = "govuk-summary-list__row"
       )
     }

--- a/test/viewmodels/helpers/ViewMovementItemsHelperSpec.scala
+++ b/test/viewmodels/helpers/ViewMovementItemsHelperSpec.scala
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package viewmodels.helpers
+
+import base.SpecBase
+import fixtures.GetMovementResponseFixtures
+import fixtures.messages.{UnitOfMeasureMessages, ViewMovementMessages}
+import play.twirl.api.Html
+import uk.gov.hmrc.govukfrontend.views.Aliases.{HeadCell, HtmlContent, Text}
+import uk.gov.hmrc.govukfrontend.views.html.components.GovukTable
+import uk.gov.hmrc.govukfrontend.views.viewmodels.table.{Table, TableRow}
+import viewmodels.govuk.TagFluency
+import views.html.components.{link, list}
+
+class ViewMovementItemsHelperSpec extends SpecBase with GetMovementResponseFixtures with TagFluency {
+
+  lazy val helper = app.injector.instanceOf[ViewMovementItemsHelper]
+  lazy val govukTable = app.injector.instanceOf[GovukTable]
+  lazy val link = app.injector.instanceOf[link]
+  lazy val list = app.injector.instanceOf[list]
+
+  val movementResponseWithReferenceData = getMovementResponseModel.copy(items = Seq(
+    item1WithPackagingAndUnitOfMeasure,
+    item2WithPackagingAndUnitOfMeasure
+  ))
+
+  ".constructSelectItems" must {
+
+    Seq(ViewMovementMessages.English -> UnitOfMeasureMessages.English).foreach {
+      case (messagesForLang, unitOfMeasureMessages) =>
+
+      s"when rendering in language code of '${messagesForLang.lang.code}'" must {
+
+        implicit lazy val msgs = messages(Seq(messagesForLang.lang))
+
+        "return a table of all items from the movement formatted with the correct wording" in {
+
+          val result = helper.constructMovementItems(movementResponseWithReferenceData)
+
+          result mustBe govukTable(
+            Table(
+              firstCellIsHeader = true,
+              head = Some(Seq(
+                HeadCell(Text(messagesForLang.itemsTableItemHeading)),
+                HeadCell(Text(messagesForLang.itemsTableCommercialDescriptionHeading)),
+                HeadCell(Text(messagesForLang.itemsTableQuantityHeading)),
+                HeadCell(Text(messagesForLang.itemsTablePackagingHeading))
+//              TODO: Add in as part of ETFE-2882
+//              HeadCell(Text(messagesForLang.itemsTableReceiptHeading))
+              )),
+              rows = Seq(
+                Seq(
+                  TableRow(
+                    content = HtmlContent(link(
+                      link = testOnly.controllers.routes.UnderConstructionController.onPageLoad().url,
+                      messageKey = messagesForLang.itemsTableItemRow(1)
+                    )),
+                    classes = "white-space-nowrap"
+                  ),
+                  TableRow(
+                    content = Text(item1WithPackagingAndUnitOfMeasure.commercialDescription.get),
+                    classes = "govuk-!-width-one-third"
+                  ),
+                  TableRow(
+                    content = Text(s"${item1WithPackagingAndUnitOfMeasure.quantity} ${unitOfMeasureMessages.kilogramsShort}")
+                  ),
+                  TableRow(
+                    content = HtmlContent(list(item1WithPackagingAndUnitOfMeasure.packaging.map(pckg =>
+                      Html(pckg.typeOfPackage)
+                    )))
+                  )
+//                TODO: Add in as part of ETFE-2882
+//                TableRow(
+//                  content = HtmlContent(govukTag(TagViewModel(Text(messagesForLang.itemsReceiptStatusNotReceipted)).grey())),
+//                  classes = "white-space-nowrap"
+//                )
+                ),
+                Seq(
+                  TableRow(
+                    content = HtmlContent(link(
+                      link = testOnly.controllers.routes.UnderConstructionController.onPageLoad().url,
+                      messageKey = messagesForLang.itemsTableItemRow(2)
+                    )),
+                    classes = "white-space-nowrap"
+                  ),
+                  TableRow(
+                    content = Text(item2WithPackagingAndUnitOfMeasure.commercialDescription.get),
+                    classes = "govuk-!-width-one-third"
+                  ),
+                  TableRow(
+                    content = Text(s"${item2WithPackagingAndUnitOfMeasure.quantity} ${unitOfMeasureMessages.kilogramsShort}")
+                  ),
+                  TableRow(
+                    content = HtmlContent(list(item2WithPackagingAndUnitOfMeasure.packaging.map(pckg =>
+                      Html(pckg.typeOfPackage)
+                    )))
+                  )
+//                TODO: Add in as part of ETFE-2882
+//                TableRow(
+//                  content = HtmlContent(govukTag(TagViewModel(Text(messagesForLang.itemsReceiptStatusNotReceipted)).grey())),
+//                  classes = "white-space-nowrap"
+//                )
+                )
+              )
+            )
+          )
+        }
+      }
+    }
+  }
+}

--- a/test/viewmodels/helpers/ViewMovementItemsHelperSpec.scala
+++ b/test/viewmodels/helpers/ViewMovementItemsHelperSpec.scala
@@ -19,12 +19,12 @@ package viewmodels.helpers
 import base.SpecBase
 import fixtures.GetMovementResponseFixtures
 import fixtures.messages.{UnitOfMeasureMessages, ViewMovementMessages}
-import play.twirl.api.Html
+import play.twirl.api.{Html, HtmlFormat}
 import uk.gov.hmrc.govukfrontend.views.Aliases.{HeadCell, HtmlContent, Text}
 import uk.gov.hmrc.govukfrontend.views.html.components.GovukTable
 import uk.gov.hmrc.govukfrontend.views.viewmodels.table.{Table, TableRow}
 import viewmodels.govuk.TagFluency
-import views.html.components.{link, list}
+import views.html.components.{h2, link, list}
 
 class ViewMovementItemsHelperSpec extends SpecBase with GetMovementResponseFixtures with TagFluency {
 
@@ -32,6 +32,7 @@ class ViewMovementItemsHelperSpec extends SpecBase with GetMovementResponseFixtu
   lazy val govukTable = app.injector.instanceOf[GovukTable]
   lazy val link = app.injector.instanceOf[link]
   lazy val list = app.injector.instanceOf[list]
+  lazy val h2 = app.injector.instanceOf[h2]
 
   val movementResponseWithReferenceData = getMovementResponseModel.copy(items = Seq(
     item1WithPackagingAndUnitOfMeasure,
@@ -51,8 +52,9 @@ class ViewMovementItemsHelperSpec extends SpecBase with GetMovementResponseFixtu
 
           val result = helper.constructMovementItems(movementResponseWithReferenceData)
 
-          result mustBe govukTable(
-            Table(
+          result mustBe HtmlFormat.fill(Seq(
+            h2(messagesForLang.itemsH2),
+            govukTable(Table(
               firstCellIsHeader = true,
               head = Some(Seq(
                 HeadCell(Text(messagesForLang.itemsTableItemHeading)),
@@ -116,8 +118,8 @@ class ViewMovementItemsHelperSpec extends SpecBase with GetMovementResponseFixtu
 //                )
                 )
               )
-            )
-          )
+            ))
+          ))
         }
       }
     }


### PR DESCRIPTION
This PR is quite big,  story wasn't a 2. Had to copy over the CnCodeInfo connector and the Packaging connector to retrieve information from the reference-data service for the item. As well as associated services and tests.

I created a `GetMovementService` layer to orchestrate the calls to those; so that you can ask for `A Movement` and then have it returned with the packaging description and the Unit of Measure as part of the response. Which should hopefully simplify other places where this is needed.

This PR does NOT include the `Receipt` column. A separate sub-task ETFE-2882 has been raised to add that in. As there is a dependency on a BE change to return the `ie818` information if a Report of Receipt exists. ETFE-2864 and ETFE-2858 need to be played and merged into `main` before that sub-task for the `Receipt` column can be progressed.