### PR TITLE
[ETFE-3587] Add boiler plate for BaseController, BaseNavigation, BaseUserAnswersService, BaseUserAnswersRepo etc.

### DIFF
--- a/app/controllers/BaseController.scala
+++ b/app/controllers/BaseController.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import models.common.Enumerable
+import models.requests.{DataRequest, UserAnswersRequest}
+import pages.QuestionPage
+import play.api.data.Form
+import play.api.i18n.I18nSupport
+import play.api.libs.json.{Format, Reads}
+import play.api.mvc.{Call, Result}
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
+import utils.Logging
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait BaseController extends FrontendBaseController with I18nSupport with Enumerable.Implicits with Logging {
+
+  implicit lazy val ec: ExecutionContext = controllerComponents.executionContext
+
+  def fillForm[A](page: QuestionPage[A], form: Form[A])
+                 (implicit request: UserAnswersRequest[_], format: Format[A]): Form[A] =
+    request.userAnswers.get(page).fold(form)(form.fill)
+}

--- a/app/controllers/BaseController.scala
+++ b/app/controllers/BaseController.scala
@@ -17,16 +17,15 @@
 package controllers
 
 import models.common.Enumerable
-import models.requests.{DataRequest, UserAnswersRequest}
+import models.requests.UserAnswersRequest
 import pages.QuestionPage
 import play.api.data.Form
 import play.api.i18n.I18nSupport
-import play.api.libs.json.{Format, Reads}
-import play.api.mvc.{Call, Result}
+import play.api.libs.json.Format
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 import utils.Logging
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.ExecutionContext
 
 trait BaseController extends FrontendBaseController with I18nSupport with Enumerable.Implicits with Logging {
 

--- a/app/controllers/BaseNavigationController.scala
+++ b/app/controllers/BaseNavigationController.scala
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import models._
+import models.requests.UserAnswersRequest
+import navigation.BaseNavigator
+import pages.QuestionPage
+import play.api.libs.json.{Format, Reads}
+import play.api.mvc.Result
+import queries.Derivable
+import repositories.BaseUserAnswersRepository
+import uk.gov.hmrc.http.HeaderCarrier
+import utils.Logging
+
+import scala.concurrent.Future
+
+trait BaseNavigationController extends BaseController with Logging {
+
+  val userAnswersRepo: BaseUserAnswersRepository
+  val navigator: BaseNavigator
+
+  def saveAndRedirect[A](page: QuestionPage[A], answer: A, currentAnswers: UserAnswers, mode: Mode)
+                        (implicit hc: HeaderCarrier, format: Format[A]): Future[Result] =
+    save(page, answer, currentAnswers).map { updatedAnswers =>
+      Redirect(navigator.nextPage(page, mode, updatedAnswers))
+    }
+
+  def saveAndRedirect[A](page: QuestionPage[A], answer: A, mode: Mode)
+                        (implicit request: UserAnswersRequest[_], format: Format[A]): Future[Result] =
+    save(page, answer, request.userAnswers).map { updatedAnswers =>
+      Redirect(navigator.nextPage(page, mode, updatedAnswers))
+    }
+
+  private def save[A](page: QuestionPage[A], answer: A, currentAnswers: UserAnswers)(implicit hc: HeaderCarrier, format: Format[A]): Future[UserAnswers] =
+    if (currentAnswers.get[A](page).contains(answer)) {
+      Future.successful(currentAnswers)
+    } else {
+      for {
+        updatedAnswers <- Future.successful(currentAnswers.set(page, answer))
+        _ <- userAnswersRepo.set(updatedAnswers)
+      } yield updatedAnswers
+    }
+
+  def validateIndex[T, A](
+                           itemCount: Derivable[T, Int], idx: Index
+                         )(onSuccess: => A, onFailure: => A)(implicit request: UserAnswersRequest[_], reads: Reads[T]): A = {
+    request.userAnswers.get(itemCount) match {
+      case Some(value) if idx.position >= 0 && idx.position < value => onSuccess
+      case _ => onFailure
+    }
+  }
+}

--- a/app/controllers/predicates/BaseUserAnswersDataRetrievalAction.scala
+++ b/app/controllers/predicates/BaseUserAnswersDataRetrievalAction.scala
@@ -19,21 +19,17 @@ package controllers.predicates
 import models.requests.{DataRequest, UserAnswersRequest}
 import play.api.mvc.Results.Redirect
 import play.api.mvc.{ActionRefiner, Result}
-import repositories.{BaseUserAnswersRepository, PreValidateTraderUserAnswersRepository}
+import services.BaseUserAnswersService
 
-import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
-class PreValidateTraderDataRetrievalAction @Inject()(override val userAnswers: PreValidateTraderUserAnswersRepository)
-                                                    (override implicit val executionContext: ExecutionContext) extends UserAnswersDataRetrievalAction
+trait BaseUserAnswersDataRetrievalAction extends ActionRefiner[DataRequest, UserAnswersRequest] {
 
-trait UserAnswersDataRetrievalAction extends ActionRefiner[DataRequest, UserAnswersRequest] {
-
-  val userAnswers: BaseUserAnswersRepository
+  val userAnswersService: BaseUserAnswersService
   implicit val executionContext: ExecutionContext
 
   override protected def refine[A](request: DataRequest[A]): Future[Either[Result, UserAnswersRequest[A]]] =
-    userAnswers.get(request.ern).map {
+    userAnswersService.get(request.ern).map {
       case Some(answers) => Right(UserAnswersRequest(request, answers))
       case _ => Left(Redirect(controllers.prevalidateTrader.routes.StartPrevalidateTraderController.onPageLoad(request.ern)))
     }

--- a/app/controllers/predicates/PreValidateTraderDataRetrievalAction.scala
+++ b/app/controllers/predicates/PreValidateTraderDataRetrievalAction.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.predicates
+
+import services.PreValidateTraderUserAnswersService
+
+import javax.inject.Inject
+import scala.concurrent.ExecutionContext
+
+class PreValidateTraderDataRetrievalAction @Inject()(override val userAnswersService: PreValidateTraderUserAnswersService)
+                                                    (override implicit val executionContext: ExecutionContext) extends BaseUserAnswersDataRetrievalAction

--- a/app/controllers/predicates/UserAnswersDataRetrievalAction.scala
+++ b/app/controllers/predicates/UserAnswersDataRetrievalAction.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.predicates
+
+import models.requests.{DataRequest, UserAnswersRequest}
+import play.api.mvc.Results.Redirect
+import play.api.mvc.{ActionRefiner, Result}
+import repositories.{BaseUserAnswersRepository, PreValidateTraderUserAnswersRepository}
+
+import javax.inject.Inject
+import scala.concurrent.{ExecutionContext, Future}
+
+class PreValidateTraderDataRetrievalAction @Inject()(override val userAnswers: PreValidateTraderUserAnswersRepository)
+                                                    (override implicit val executionContext: ExecutionContext) extends UserAnswersDataRetrievalAction
+
+trait UserAnswersDataRetrievalAction extends ActionRefiner[DataRequest, UserAnswersRequest] {
+
+  val userAnswers: BaseUserAnswersRepository
+  implicit val executionContext: ExecutionContext
+
+  override protected def refine[A](request: DataRequest[A]): Future[Either[Result, UserAnswersRequest[A]]] =
+    userAnswers.get(request.ern).map {
+      case Some(answers) => Right(UserAnswersRequest(request, answers))
+      case _ => Left(Redirect(controllers.prevalidateTrader.routes.StartPrevalidateTraderController.onPageLoad(request.ern)))
+    }
+}

--- a/app/controllers/prevalidateTrader/BasePreValidateNavigationController.scala
+++ b/app/controllers/prevalidateTrader/BasePreValidateNavigationController.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.prevalidateTrader
+
+import controllers.BaseNavigationController
+import models.Index
+import models.requests.UserAnswersRequest
+import play.api.mvc.Result
+import queries.PreValidateTraderEPCCount
+
+import scala.concurrent.Future
+
+trait BasePreValidateNavigationController extends BaseNavigationController {
+
+  def validateIndex(index: Index)(onSuccess: => Result)(implicit request: UserAnswersRequest[_]): Result = {
+    super.validateIndex(PreValidateTraderEPCCount, index)(
+      onSuccess,
+      Redirect(controllers.prevalidateTrader.routes.StartPrevalidateTraderController.onPageLoad(request.ern))
+    )
+  }
+
+  def validateIndexAsync(index: Index)(onSuccess: => Future[Result])(implicit request: UserAnswersRequest[_]): Future[Result] = {
+    super.validateIndex(PreValidateTraderEPCCount, index)(
+      onSuccess,
+      Future.successful(Redirect(controllers.prevalidateTrader.routes.StartPrevalidateTraderController.onPageLoad(request.ern)))
+    )
+  }
+}

--- a/app/models/Index.scala
+++ b/app/models/Index.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import play.api.mvc.PathBindable
+
+import scala.util.{Failure, Success, Try}
+
+case class Index(position: Int) {
+  val displayIndex: String = s"${position + 1}"
+}
+
+object Index {
+
+  implicit def intToIndex(int: Int): Index = Index(int)
+
+  implicit val pathBindable: PathBindable[Index] = new PathBindable[Index] {
+    override def bind(key: String, value: String): Either[String, Index] = Try(value.toInt) match {
+      case Failure(_) => Left("could not parse index")
+      case Success(idx) => Right(Index(idx - 1))
+    }
+
+    override def unbind(key: String, value: Index): String = value.displayIndex
+  }
+}

--- a/app/models/Mode.scala
+++ b/app/models/Mode.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,12 +14,19 @@
  * limitations under the License.
  */
 
-package pages
+package models
 
-import scala.language.implicitConversions
+import play.api.mvc.JavascriptLiteral
 
-trait Page
+sealed trait Mode
 
-object Page {
-  implicit def toString(page: Page): String = page.toString
+case object CheckMode extends Mode
+
+case object NormalMode extends Mode
+
+object Mode {
+  implicit val jsLiteral: JavascriptLiteral[Mode] = {
+    case NormalMode => "NormalMode"
+    case CheckMode => "CheckMode"
+  }
 }

--- a/app/models/UserAnswers.scala
+++ b/app/models/UserAnswers.scala
@@ -18,13 +18,38 @@ package models
 
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
+import queries.{Derivable, Gettable, Settable}
 import uk.gov.hmrc.mongo.play.json.formats.MongoJavatimeFormats
 
 import java.time.Instant
 
 final case class UserAnswers(ern: String,
                              data: JsObject,
-                             lastUpdated: Instant)
+                             lastUpdated: Instant) {
+
+  def get[A](page: Gettable[A])(implicit rds: Reads[A]): Option[A] =
+    Reads.optionNoError(Reads.at(page.path)).reads(data).asOpt.flatten
+
+  def get[A, B](query: Derivable[A, B])(implicit rds: Reads[A]): Option[B] =
+    get(query.asInstanceOf[Gettable[A]]).map(query.derive)
+
+  def set[A](page: Settable[A], value: A)(implicit writes: Writes[A]): UserAnswers =
+    handleResult {
+      data.setObject(page.path, Json.toJson(value))
+    }
+
+  def remove[A](page: Settable[A]): UserAnswers =
+    handleResult {
+      data.removeObject(page.path)
+    }
+
+  private[models] def handleResult: JsResult[JsObject] => UserAnswers = {
+    case JsSuccess(updatedAnswers, _) =>
+      copy(data = updatedAnswers)
+    case JsError(errors) =>
+      throw JsResultException(errors)
+  }
+}
 
 object UserAnswers {
 

--- a/app/models/package.scala
+++ b/app/models/package.scala
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import play.api.libs.json._
+
+import scala.util.Try
+
+package object models {
+
+  implicit class RichJsObject(jsObject: JsObject) {
+
+    def setObject(path: JsPath, value: JsValue): JsResult[JsObject] =
+      jsObject.set(path, value).flatMap(_.validate[JsObject])
+
+    def removeObject(path: JsPath): JsResult[JsObject] =
+      jsObject.remove(path).flatMap(_.validate[JsObject])
+  }
+
+  implicit class RichJsValue(jsValue: JsValue) {
+
+    def set(path: JsPath, value: JsValue): JsResult[JsValue] =
+      (path.path, jsValue) match {
+
+        case (Nil, _) =>
+          JsError("path cannot be empty")
+
+        case ((_: RecursiveSearch) :: _, _) =>
+          JsError("recursive search not supported")
+
+        case ((n: IdxPathNode) :: Nil, _) =>
+          setIndexNode(n, jsValue, value)
+
+        case ((n: KeyPathNode) :: Nil, _) =>
+          setKeyNode(n, jsValue, value)
+
+        case (first :: second :: rest, oldValue) =>
+          Reads.optionNoError(Reads.at[JsValue](JsPath(first :: Nil)))
+            .reads(oldValue).flatMap {
+            opt =>
+
+              opt.map(JsSuccess(_)).getOrElse {
+                second match {
+                  case _: KeyPathNode =>
+                    JsSuccess(Json.obj())
+                  case _: IdxPathNode =>
+                    JsSuccess(Json.arr())
+                  case _: RecursiveSearch =>
+                    JsError("recursive search is not supported")
+                }
+              }.flatMap {
+                _.set(JsPath(second :: rest), value).flatMap {
+                  newValue =>
+                    oldValue.set(JsPath(first :: Nil), newValue)
+                }
+              }
+          }
+      }
+
+    private def setIndexNode(node: IdxPathNode, oldValue: JsValue, newValue: JsValue): JsResult[JsValue] = {
+
+      val index: Int = node.idx
+
+      oldValue match {
+        case oldValue: JsArray if index >= 0 && index <= oldValue.value.length =>
+          if (index == oldValue.value.length) {
+            JsSuccess(oldValue.append(newValue))
+          } else {
+            JsSuccess(JsArray(oldValue.value.updated(index, newValue)))
+          }
+        case oldValue: JsArray =>
+          JsError(s"array index out of bounds: $index, $oldValue")
+        case _ =>
+          JsError(s"cannot set an index on $oldValue")
+      }
+    }
+
+    private def removeIndexNode(node: IdxPathNode, valueToRemoveFrom: JsArray): JsResult[JsValue] = {
+      val index: Int = node.idx
+
+      valueToRemoveFrom match {
+        case valueToRemoveFrom: JsArray if index >= 0 && index < valueToRemoveFrom.value.length =>
+          val updatedJsArray = valueToRemoveFrom.value.slice(0, index) ++ valueToRemoveFrom.value.slice(index + 1, valueToRemoveFrom.value.size)
+          JsSuccess(JsArray(updatedJsArray))
+        case valueToRemoveFrom: JsArray => JsError(s"array index out of bounds: $index, $valueToRemoveFrom")
+        case _ => JsError(s"cannot set an index on $valueToRemoveFrom")
+      }
+    }
+
+    private def setKeyNode(node: KeyPathNode, oldValue: JsValue, newValue: JsValue): JsResult[JsValue] = {
+
+      val key = node.key
+
+      oldValue match {
+        case oldValue: JsObject =>
+          JsSuccess(oldValue + (key -> newValue))
+        case _ =>
+          JsError(s"cannot set a key on $oldValue")
+      }
+    }
+
+    def remove(path: JsPath): JsResult[JsValue] =
+      (path.path, jsValue) match {
+        case (Nil, _) => JsError("path cannot be empty")
+        case ((n: KeyPathNode) :: Nil, value: JsObject) if value.keys.contains(n.key) => JsSuccess(value - n.key)
+        case ((n: KeyPathNode) :: Nil, value: JsObject) if !value.keys.contains(n.key) => JsSuccess(value)
+        case ((idx: IdxPathNode) :: (pageKey: KeyPathNode) :: Nil, array: JsArray) => removeAtSubPathArray(array, idx, pageKey.key)
+        case ((n: IdxPathNode) :: Nil, value: JsArray) => removeIndexNode(n, value)
+        case ((_: KeyPathNode) :: Nil, _) => JsError(s"cannot remove a key on $jsValue")
+        case (first :: second :: rest, oldValue) =>
+
+          Reads.optionNoError(Reads.at[JsValue](JsPath(first :: Nil)))
+            .reads(oldValue).flatMap {
+            opt: Option[JsValue] =>
+
+              opt.map(JsSuccess(_)).getOrElse {
+                second match {
+                  case _: KeyPathNode =>
+                    JsSuccess(Json.obj())
+                  case _: IdxPathNode =>
+                    JsSuccess(Json.arr())
+                  case _: RecursiveSearch =>
+                    JsError("recursive search is not supported")
+                }
+              }.flatMap {
+                _.remove(JsPath(second :: rest)).flatMap {
+                  newValue =>
+                    oldValue.set(JsPath(first :: Nil), newValue)
+                }
+              }
+          }
+      }
+
+    private def removeAtSubPathArray(array: JsArray, idx: IdxPathNode, pageKey: String): JsResult[JsValue] =
+      Try(array.value(idx.idx)).toOption match {
+        case Some(obj) =>
+          val jsObj = obj.as[JsObject]
+          if (jsObj.keys.size == 1 && jsObj.keys.headOption.contains(pageKey)) {
+            removeIndexNode(idx, array)
+          } else {
+            JsSuccess(JsArray(
+              array.value.slice(0, idx.idx) ++ Seq((jsObj - pageKey).as[JsValue]) ++ array.value.slice(idx.idx + 1, array.value.size)
+            ))
+          }
+        case None =>
+          JsSuccess(array)
+      }
+  }
+}

--- a/app/models/requests/UserAnswersRequest.scala
+++ b/app/models/requests/UserAnswersRequest.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.requests
+
+import models.UserAnswers
+import models.common.RoleType.RoleType
+import play.api.mvc.WrappedRequest
+
+case class UserAnswersRequest[A](request: DataRequest[A], userAnswers: UserAnswers) extends WrappedRequest[A](request) {
+  val internalId: String = request.internalId
+  val ern: String = request.ern
+  val isWarehouseKeeper: Boolean = request.isWarehouseKeeper
+  val isRegisteredConsignor: Boolean = request.isRegisteredConsignor
+  val userTypeFromErn: RoleType = request.userTypeFromErn
+  val traderKnownFacts = request.traderKnownFacts
+  val messageStatistics = request.messageStatistics
+}

--- a/app/navigation/BaseNavigator.scala
+++ b/app/navigation/BaseNavigator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
-package pages
+package navigation
 
-import scala.language.implicitConversions
+import models.{Mode, UserAnswers}
+import pages.Page
+import play.api.mvc.Call
 
-trait Page
+abstract class BaseNavigator {
 
-object Page {
-  implicit def toString(page: Page): String = page.toString
+  def nextPage(page: Page, mode: Mode, userAnswers: UserAnswers): Call
+
 }

--- a/app/navigation/PreValidateTraderNavigator.scala
+++ b/app/navigation/PreValidateTraderNavigator.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package navigation
+
+import models.{CheckMode, Mode, NormalMode, UserAnswers}
+import pages.Page
+import play.api.mvc.Call
+
+import javax.inject.Inject
+
+class PreValidateTraderNavigator @Inject() extends BaseNavigator {
+
+  private val normalRoutes: Page => UserAnswers => Call = {
+    case _ => (userAnswers: UserAnswers) =>
+      //TODO: Route to Add to List page
+      ???
+  }
+
+  private[navigation] val checkRouteMap: Page => UserAnswers => Call = {
+    case _ => (userAnswers: UserAnswers) =>
+      //TODO: Route to Add to List pages
+      ???
+  }
+
+  override def nextPage(page: Page, mode: Mode, userAnswers: UserAnswers): Call = mode match {
+    case NormalMode =>
+      normalRoutes(page)(userAnswers)
+    case CheckMode =>
+      checkRouteMap(page)(userAnswers)
+  }
+}

--- a/app/pages/QuestionPage.scala
+++ b/app/pages/QuestionPage.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,7 @@
 
 package pages
 
-import scala.language.implicitConversions
+import queries.{Gettable, Settable}
 
-trait Page
+trait QuestionPage[+A] extends Page with Gettable[A] with Settable[A]
 
-object Page {
-  implicit def toString(page: Page): String = page.toString
-}

--- a/app/pages/ViewAllMessagesPage.scala
+++ b/app/pages/ViewAllMessagesPage.scala
@@ -16,10 +16,6 @@
 
 package pages
 
-import scala.language.implicitConversions
-
-trait Page
-
-object Page {
-  implicit def toString(page: Page): String = page.toString
+case object ViewAllMessagesPage extends Page {
+  override val toString: String = "viewAllMessages"
 }

--- a/app/pages/ViewMessagePage.scala
+++ b/app/pages/ViewMessagePage.scala
@@ -16,10 +16,6 @@
 
 package pages
 
-import scala.language.implicitConversions
-
-trait Page
-
-object Page {
-  implicit def toString(page: Page): String = page.toString
+case object ViewMessagePage extends Page {
+  override val toString: String = "viewMessage"
 }

--- a/app/pages/prevalidateTrader/PreValidateAddedProductCodes.scala
+++ b/app/pages/prevalidateTrader/PreValidateAddedProductCodes.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
-package pages
+package pages.prevalidateTrader
 
-import scala.language.implicitConversions
+import pages.QuestionPage
+import play.api.libs.json.{JsObject, JsPath}
 
-trait Page
+case object PreValidateAddedProductCodes extends QuestionPage[JsObject] {
 
-object Page {
-  implicit def toString(page: Page): String = page.toString
+  override val path: JsPath = PreValidateTraderSection.path \ "addedProductCodes"
+  val max: Int = 10
+  
 }

--- a/app/pages/prevalidateTrader/PreValidateProductCode.scala
+++ b/app/pages/prevalidateTrader/PreValidateProductCode.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
-package pages
+package pages.prevalidateTrader
 
-import scala.language.implicitConversions
+import models.Index
+import pages.QuestionPage
+import play.api.libs.json.{JsObject, JsPath}
 
-trait Page
+case class PreValidateProductCode(idx: Index) extends QuestionPage[JsObject] {
 
-object Page {
-  implicit def toString(page: Page): String = page.toString
+  override val path: JsPath = PreValidateAddedProductCodes.path \ idx.position \ "epcCode"
+  
 }

--- a/app/pages/prevalidateTrader/PreValidateTraderSection.scala
+++ b/app/pages/prevalidateTrader/PreValidateTraderSection.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
-package pages
+package pages.prevalidateTrader
 
-import scala.language.implicitConversions
+import pages.QuestionPage
+import play.api.libs.json.{JsObject, JsPath}
 
-trait Page
+case object PreValidateTraderSection extends QuestionPage[JsObject] {
 
-object Page {
-  implicit def toString(page: Page): String = page.toString
+  override val path: JsPath = JsPath \ "preValidateTrader"
+  
 }

--- a/app/queries/Derivable.scala
+++ b/app/queries/Derivable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,12 +14,10 @@
  * limitations under the License.
  */
 
-package pages
+package queries
 
-import scala.language.implicitConversions
+import pages.QuestionPage
 
-trait Page
-
-object Page {
-  implicit def toString(page: Page): String = page.toString
+trait Derivable[A, B] extends QuestionPage[A] {
+  val derive: A => B
 }

--- a/app/queries/PreValidateTraderEPCCount.scala
+++ b/app/queries/PreValidateTraderEPCCount.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-package pages
+package queries
 
-import scala.language.implicitConversions
+import pages.prevalidateTrader.PreValidateAddedProductCodes
+import play.api.libs.json.{JsPath, JsValue}
 
-trait Page
-
-object Page {
-  implicit def toString(page: Page): String = page.toString
+case object PreValidateTraderEPCCount extends Derivable[List[JsValue], Int] {
+  override val derive: List[JsValue] => Int = _.size
+  override val path: JsPath = PreValidateAddedProductCodes.path
 }

--- a/app/queries/Query.scala
+++ b/app/queries/Query.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
-package pages
+package queries
 
-import scala.language.implicitConversions
+import play.api.libs.json.JsPath
 
-trait Page
-
-object Page {
-  implicit def toString(page: Page): String = page.toString
+sealed trait Query {
+  val path: JsPath
 }
+
+trait Gettable[+A] extends Query
+
+trait Settable[+A] extends Query

--- a/app/repositories/BaseUserAnswersRepository.scala
+++ b/app/repositories/BaseUserAnswersRepository.scala
@@ -79,19 +79,18 @@ class BaseUserAnswersRepository(collectionName: String,
       ).headOption()
     )
 
-  def set(answers: UserAnswers): Future[Boolean] = {
+  def set(answers: UserAnswers): Future[UserAnswers] = {
 
     val updatedAnswers = answers copy (lastUpdated = time.instant())
 
     Mdc.preservingMdc(
       collection
-        .replaceOne(
+        .findOneAndReplace(
           filter = by(updatedAnswers.ern),
           replacement = updatedAnswers,
-          options = ReplaceOptions().upsert(true)
+          options = FindOneAndReplaceOptions().upsert(true).returnDocument(ReturnDocument.AFTER)
         )
         .toFuture()
-        .map(_ => true)
     )
   }
 

--- a/app/services/BaseUserAnswersService.scala
+++ b/app/services/BaseUserAnswersService.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services
+
+import models.UserAnswers
+import repositories.BaseUserAnswersRepository
+
+import scala.concurrent.Future
+
+trait BaseUserAnswersService {
+
+  val userAnswersRepo: BaseUserAnswersRepository
+
+  def get(ern: String): Future[Option[UserAnswers]] =
+    userAnswersRepo.get(ern)
+  def set(answers: UserAnswers): Future[UserAnswers] =
+    userAnswersRepo.set(answers)
+
+  def remove(answers: UserAnswers): Future[Boolean] =
+    userAnswersRepo.remove(answers.ern)
+}

--- a/app/services/PreValidateTraderUserAnswersService.scala
+++ b/app/services/PreValidateTraderUserAnswersService.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services
+
+import repositories.PreValidateTraderUserAnswersRepository
+
+import javax.inject.Inject
+
+class PreValidateTraderUserAnswersService @Inject()(override val userAnswersRepo: PreValidateTraderUserAnswersRepository) extends BaseUserAnswersService

--- a/app/views/templates/Layout.scala.html
+++ b/app/views/templates/Layout.scala.html
@@ -61,7 +61,7 @@
             hmrcTimeoutDialog(TimeoutDialog(
                 timeout             = Some(appConfig.timeout),
                 countdown           = Some(appConfig.countdown),
-                keepAliveUrl        = Some(routes.KeepAliveController.keepAlive.url),
+                keepAliveUrl        = Some(routes.KeepAliveController.keepAlive().url),
                 keepAliveButtonText = Some(messages("timeout.keepAlive")),
                 signOutUrl          = Some(appConfig.signOutUrl),
                 signOutButtonText   = Some(messages("timeout.signOut")),

--- a/test-utils/fixtures/BaseFixtures.scala
+++ b/test-utils/fixtures/BaseFixtures.scala
@@ -16,9 +16,14 @@
 
 package fixtures
 
+import models.UserAnswers
 import models.common.TraderKnownFacts
 import models.response.emcsTfe.GetMessageStatisticsResponse
 import play.api.libs.json.{JsValue, Json}
+import play.api.mvc.Call
+
+import java.time.Instant
+import java.time.temporal.ChronoUnit
 
 
 trait BaseFixtures {
@@ -32,6 +37,7 @@ trait BaseFixtures {
   val testLrn = "123"
   val testTraderName = "testTraderName"
   val testUniqueMessageIdentifier = 1234
+  val testOnwardRoute: Call = Call("GET", "/foo")
 
   val testDutyPaidErn = "XIPATestErn"
 
@@ -58,6 +64,12 @@ trait BaseFixtures {
        |   "countOfAllMessages" : 1,
        |   "countOfNewMessages" : 1
        |}""".stripMargin
+  )
+
+  val emptyUserAnswers: UserAnswers = UserAnswers(
+    ern = testErn,
+    data = Json.obj(),
+    lastUpdated = Instant.now().truncatedTo(ChronoUnit.MILLIS)
   )
 
 }

--- a/test/base/SpecBase.scala
+++ b/test/base/SpecBase.scala
@@ -18,8 +18,9 @@ package base
 
 import config.{AppConfig, ErrorHandler}
 import fixtures.BaseFixtures
+import models.UserAnswers
 import models.auth.UserRequest
-import models.requests.DataRequest
+import models.requests.{DataRequest, UserAnswersRequest}
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.OptionValues
 import org.scalatest.concurrent.ScalaFutures
@@ -46,5 +47,8 @@ trait SpecBase extends AnyWordSpecLike with Matchers with MockFactory with Optio
 
   def dataRequest[A](request: Request[A], ern: String = testErn): DataRequest[A] =
     DataRequest(userRequest(request, ern), testMinTraderKnownFacts, testMessageStatistics)
+
+  def userAnswersRequest[A](request: Request[A], userAnswers: UserAnswers = emptyUserAnswers): UserAnswersRequest[A] =
+    UserAnswersRequest(dataRequest(request, userAnswers.ern), userAnswers)
 
 }

--- a/test/controllers/BaseControllerSpec.scala
+++ b/test/controllers/BaseControllerSpec.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import base.SpecBase
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import pages.QuestionPage
+import play.api.data.Form
+import play.api.data.Forms.nonEmptyText
+import play.api.libs.json.{JsPath, __}
+import play.api.mvc.MessagesControllerComponents
+import play.api.test.FakeRequest
+
+class BaseControllerSpec extends SpecBase with GuiceOneAppPerSuite {
+
+  val page = new QuestionPage[String] {
+    override val path: JsPath = __ \ "page1"
+  }
+
+  val form = Form("value" -> nonEmptyText)
+
+  lazy val testController = new BaseController {
+    override protected def controllerComponents: MessagesControllerComponents = messagesControllerComponents
+  }
+
+  "fillForm" when {
+    "when no answer exists for the page" must {
+      "return the form unfilled" in {
+
+        implicit val request = userAnswersRequest(FakeRequest())
+        testController.fillForm(page, form).value mustBe None
+      }
+    }
+
+    "when an answer DOES exist for the page" must {
+      "return the form with answer filled in" in {
+
+        implicit val request = userAnswersRequest(FakeRequest(), emptyUserAnswers.set(page, "foo"))
+        testController.fillForm(page, form).value mustBe Some("foo")
+      }
+    }
+  }
+}

--- a/test/controllers/BaseNavigationControllerSpec.scala
+++ b/test/controllers/BaseNavigationControllerSpec.scala
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import base.SpecBase
+import mocks.services.MockUserAnswersService
+import models.auth.UserRequest
+import models.{Index, NormalMode, UserAnswers}
+import navigation.BaseNavigator
+import navigation.FakeNavigators.FakeNavigator
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import pages.QuestionPage
+import play.api.libs.json.{JsObject, JsPath, __}
+import play.api.mvc.{AnyContentAsEmpty, MessagesControllerComponents, Result}
+import play.api.test.FakeRequest
+import play.api.test.Helpers.{GET, redirectLocation}
+import queries.Derivable
+import services.BaseUserAnswersService
+import uk.gov.hmrc.http.HeaderCarrier
+
+import scala.concurrent.Future
+
+class BaseNavigationControllerSpec extends SpecBase with GuiceOneAppPerSuite with MockUserAnswersService {
+  trait Test {
+    implicit val hc: HeaderCarrier = HeaderCarrier()
+
+    implicit val request: UserRequest[AnyContentAsEmpty.type] = userRequest(FakeRequest(GET, "/foo/bar"))
+
+    val page = new QuestionPage[String] {
+      override val path: JsPath = __ \ "page1"
+    }
+    val page2 = new QuestionPage[String] {
+      override val path: JsPath = __ \ "page2"
+    }
+    val value = "foo"
+
+    case class TestIndexPage(index: Index) extends QuestionPage[String] {
+      override val path: JsPath = TestDerivable.path \ index.position \ "test"
+    }
+
+    object TestDerivable extends Derivable[Seq[JsObject], Int] {
+      override val derive: Seq[JsObject] => Int = _.size
+
+      override val path: JsPath = JsPath \ "something"
+    }
+
+    val testNavigator = new FakeNavigator(testOnwardRoute)
+
+    lazy val testController = new BaseNavigationController with BaseController {
+      override val userAnswersService: BaseUserAnswersService = mockUserAnswersService
+      override val navigator: BaseNavigator = testNavigator
+
+      override protected def controllerComponents: MessagesControllerComponents = messagesControllerComponents
+    }
+  }
+
+  "saveAndRedirect" when {
+    "with currentAnswers" must {
+      "save the answer and redirect" when {
+        "current UserAnswers doesn't contain the input answer" in new Test {
+          val newUserAnswers: UserAnswers = emptyUserAnswers.set(page, value)
+
+          MockUserAnswersService.set().returns(Future.successful(newUserAnswers))
+
+          val answer: Future[Result] =
+            testController.saveAndRedirect(page, value, emptyUserAnswers, NormalMode)
+
+          redirectLocation(answer) mustBe Some(testOnwardRoute.url)
+        }
+      }
+
+      "only redirect" when {
+        "current UserAnswers contains the input answer" in new Test {
+          val newUserAnswers: UserAnswers = emptyUserAnswers.set(page, value)
+
+          MockUserAnswersService.set().never()
+
+          val answer: Future[Result] =
+            testController.saveAndRedirect(page, value, newUserAnswers, NormalMode)
+
+          redirectLocation(answer) mustBe Some(testOnwardRoute.url)
+        }
+      }
+    }
+
+    "without currentAnswers" must {
+      "save the answer and redirect" in new Test {
+        val newUserAnswers: UserAnswers = emptyUserAnswers.set(page, value)
+
+        MockUserAnswersService.set().returns(Future.successful(newUserAnswers))
+
+        val answer: Future[Result] =
+          testController.saveAndRedirect(page, value, NormalMode)(userAnswersRequest(FakeRequest()), implicitly)
+
+        redirectLocation(answer) mustBe Some(testOnwardRoute.url)
+      }
+    }
+  }
+
+  "validateIndex" should {
+
+    "must run the onSuccess function" should {
+      "when index is for a new page where index exists in previous items" in new Test {
+        val result: Boolean =
+          testController.validateIndex(
+            TestDerivable, Index(2)
+          )(
+            true, false
+          )(
+            userAnswersRequest(FakeRequest(), emptyUserAnswers
+              .set(TestIndexPage(Index(0)), "answer")
+              .set(TestIndexPage(Index(1)), "answer")
+              .set(TestIndexPage(Index(2)), "answer")
+              .set(TestIndexPage(Index(3)), "answer")
+            ), implicitly
+          )
+
+        result mustBe true
+      }
+    }
+    "must run the onFailure function" should {
+      "when no user answers present and value is Index(0)" in new Test {
+        val result: Boolean =
+          testController.validateIndex(TestDerivable, Index(0))(true, false)(userAnswersRequest(FakeRequest(), emptyUserAnswers), implicitly)
+
+        result mustBe false
+      }
+
+      "when index is greater than last index in user answers" in new Test {
+        val result: Boolean =
+          testController.validateIndex(
+            TestDerivable, Index(2)
+          )(
+            true, false
+          )(
+            userAnswersRequest(FakeRequest(), emptyUserAnswers
+              .set(TestIndexPage(Index(0)), "answer")
+              .set(TestIndexPage(Index(1)), "answer")
+            ), implicitly
+          )
+
+        result mustBe false
+      }
+    }
+  }
+}

--- a/test/controllers/predicates/PreValidateTraderUserAnswersActionSpec.scala
+++ b/test/controllers/predicates/PreValidateTraderUserAnswersActionSpec.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.predicates
+
+import base.SpecBase
+import mocks.services.MockPreValidateUserAnswersService
+import models.UserAnswers
+import models.requests.UserAnswersRequest
+import org.scalamock.scalatest.MockFactory
+import play.api.libs.json.Json
+import play.api.mvc.Result
+import play.api.mvc.Results.Ok
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+
+import java.time.Instant
+import scala.concurrent.{ExecutionContext, Future}
+
+class PreValidateTraderUserAnswersActionSpec extends SpecBase with MockFactory with MockPreValidateUserAnswersService {
+
+  implicit val ec: ExecutionContext = app.injector.instanceOf[ExecutionContext]
+
+  lazy val action: PreValidateTraderDataRetrievalAction = new PreValidateTraderDataRetrievalAction(mockUserAnswersService)
+
+  class Harness() {
+
+    lazy val result: Future[Result] = action.invokeBlock(dataRequest(FakeRequest()), { _: UserAnswersRequest[_] =>
+      Future.successful(Ok)
+    })
+  }
+
+  "BetaAllowListAction" should {
+
+    "when data is returned from the UserAnswersService" must {
+
+      "must execute the supplied block" in new Harness() {
+        MockUserAnswersService.get(testErn).returns(Future.successful(Some(UserAnswers(testErn, Json.obj(), Instant.now()))))
+        status(result) mustBe OK
+      }
+    }
+
+    "when data is NOT returned from the UserAnswersService" must {
+
+      "must Redirect to the PreValidate Start controller" in new Harness() {
+        MockUserAnswersService.get(testErn).returns(Future.successful(None))
+        status(result) mustBe SEE_OTHER
+        redirectLocation(result) mustBe Some(controllers.prevalidateTrader.routes.StartPrevalidateTraderController.onPageLoad(testErn).url)
+      }
+    }
+  }
+}

--- a/test/mocks/services/MockUserAnswersService.scala
+++ b/test/mocks/services/MockUserAnswersService.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mocks.services
+
+import models.UserAnswers
+import org.scalamock.handlers.CallHandler1
+import org.scalamock.scalatest.MockFactory
+import services.{BaseUserAnswersService, PreValidateTraderUserAnswersService}
+
+import scala.concurrent.Future
+
+trait MockPreValidateUserAnswersService extends MockUserAnswersService {
+  override lazy val mockUserAnswersService: PreValidateTraderUserAnswersService = mock[PreValidateTraderUserAnswersService]
+}
+
+trait MockUserAnswersService extends MockFactory {
+
+
+  lazy val mockUserAnswersService: BaseUserAnswersService = mock[BaseUserAnswersService]
+
+  object MockUserAnswersService {
+
+    def get(ern: String): CallHandler1[String, Future[Option[UserAnswers]]] =
+      (mockUserAnswersService.get(_: String)).expects(ern)
+
+    def set(userAnswers: UserAnswers): CallHandler1[UserAnswers, Future[UserAnswers]] =
+      (mockUserAnswersService.set(_: UserAnswers))
+        .expects(where[UserAnswers] { actualAnswers =>
+          actualAnswers.ern == userAnswers.ern &&
+            actualAnswers.data == userAnswers.data
+        })
+
+    def set(): CallHandler1[UserAnswers, Future[UserAnswers]] =
+      (mockUserAnswersService.set(_: UserAnswers)).expects(*)
+
+    def clear(userAnswers: UserAnswers): CallHandler1[UserAnswers, Future[Boolean]] =
+      (mockUserAnswersService.remove(_: UserAnswers)).expects(userAnswers)
+  }
+}

--- a/test/models/RichJsValueSpec.scala
+++ b/test/models/RichJsValueSpec.scala
@@ -1,0 +1,325 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import org.scalatest.OptionValues
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.must.Matchers
+import play.api.libs.json._
+
+class RichJsValueSpec extends AnyFreeSpec with Matchers with OptionValues {
+
+  val min = 2
+  val max = 10
+  val nonEmptyAlphaStr: String = "beans"
+  val nonEmptyAlphaStr2: String = "eggs"
+  val nonEmptyAlphaStr3: String = "toast"
+
+  def buildJsObj[B](keys: Seq[String], values: Seq[B])(implicit writes: Writes[B]): JsObject = {
+    keys.zip(values).foldLeft(JsObject.empty) {
+      case (acc, (key, value)) => acc + (key -> Json.toJson[B](value))
+    }
+  }
+
+  "set" - {
+
+    "must return an error if the path is empty" in {
+
+      val value = Json.obj()
+
+      value.set(JsPath, Json.obj()) mustEqual JsError("path cannot be empty")
+    }
+
+    "must set a value on a JsObject" in {
+      val originalKey = nonEmptyAlphaStr
+      val originalValue = nonEmptyAlphaStr
+      val pathKey = nonEmptyAlphaStr2
+      val newValue = nonEmptyAlphaStr
+      val value = Json.obj(originalKey -> originalValue)
+
+      val path = JsPath \ pathKey
+
+      value.set(path, JsString(newValue)) mustEqual JsSuccess(Json.obj(originalKey -> originalValue, pathKey -> newValue))
+    }
+
+    "must set a nested value on a JsObject" in {
+
+      val value = Json.obj(
+        "foo" -> Json.obj()
+      )
+
+      val path = JsPath \ "foo" \ "bar"
+
+      value.set(path, JsString("baz")).asOpt.value mustEqual Json.obj(
+        "foo" -> Json.obj(
+          "bar" -> "baz"
+        )
+      )
+    }
+
+    "must add a value to an empty JsArray" in {
+      val value = Json.arr()
+
+      val path = JsPath \ 0
+
+      value.set(path, JsString(nonEmptyAlphaStr)) mustEqual JsSuccess(Json.arr(nonEmptyAlphaStr))
+    }
+
+    "must add a value to the end of a JsArray" in {
+      val (oldValue, newValue) = (nonEmptyAlphaStr, nonEmptyAlphaStr2)
+
+      val value = Json.arr(oldValue)
+
+      val path = JsPath \ 1
+
+      value.set(path, JsString(newValue)) mustEqual JsSuccess(Json.arr(oldValue, newValue))
+    }
+
+    "must change a value in an existing JsArray" in {
+      val (firstValue, secondValue, newValue) = (nonEmptyAlphaStr, nonEmptyAlphaStr2, nonEmptyAlphaStr3)
+
+      val value = Json.arr(firstValue, secondValue)
+
+      val path = JsPath \ 0
+
+      value.set(path, JsString(newValue)) mustEqual JsSuccess(Json.arr(newValue, secondValue))
+    }
+
+    "must set a nested value on a JsArray" in {
+
+      val value = Json.arr(Json.arr("foo"))
+
+      val path = JsPath \ 0 \ 0
+
+      value.set(path, JsString("bar")).asOpt.value mustEqual Json.arr(Json.arr("bar"))
+    }
+
+    "must change the value of an existing key" in {
+      val originalKey = nonEmptyAlphaStr
+      val originalValue = nonEmptyAlphaStr2
+      val newValue = nonEmptyAlphaStr3
+
+      val value = Json.obj(originalKey -> originalValue)
+
+      val path = JsPath \ originalKey
+
+      value.set(path, JsString(newValue)) mustEqual JsSuccess(Json.obj(originalKey -> newValue))
+    }
+
+    "must return an error when trying to set a key on a non-JsObject" in {
+
+      val value = Json.arr()
+
+      val path = JsPath \ "foo"
+
+      value.set(path, JsString("bar")) mustEqual JsError(s"cannot set a key on $value")
+    }
+
+    "must return an error when trying to set an index on a non-JsArray" in {
+
+      val value = Json.obj()
+
+      val path = JsPath \ 0
+
+      value.set(path, JsString("bar")) mustEqual JsError(s"cannot set an index on $value")
+    }
+
+    "must return an error when trying to set an index other than zero on an empty array" in {
+
+      val value = Json.arr()
+
+      val path = JsPath \ 1
+
+      value.set(path, JsString("bar")) mustEqual JsError("array index out of bounds: 1, []")
+    }
+
+    "must return an error when trying to set an index out of bounds" in {
+
+      val value = Json.arr("bar", "baz")
+
+      val path = JsPath \ 3
+
+      value.set(path, JsString("fork")) mustEqual JsError("array index out of bounds: 3, [\"bar\",\"baz\"]")
+    }
+
+    "must set into an array which does not exist" in {
+
+      val value = Json.obj()
+
+      val path = JsPath \ "foo" \ 0
+
+      value.set(path, JsString("bar")) mustEqual JsSuccess(Json.obj(
+        "foo" -> Json.arr("bar")
+      ))
+    }
+
+    "must set into an object which does not exist" in {
+
+      val value = Json.obj()
+
+      val path = JsPath \ "foo" \ "bar"
+
+      value.set(path, JsString("baz")) mustEqual JsSuccess(Json.obj(
+        "foo" -> Json.obj(
+          "bar" -> "baz"
+        )
+      ))
+    }
+
+    "must set nested objects and arrays" in {
+
+      val value = Json.obj()
+
+      val path = JsPath \ "foo" \ 0 \ "bar" \ 0
+
+      value.set(path, JsString("baz")) mustEqual JsSuccess(Json.obj(
+        "foo" -> Json.arr(
+          Json.obj(
+            "bar" -> Json.arr(
+              "baz"
+            )
+          )
+        )
+      ))
+    }
+  }
+
+  "remove" - {
+    "must return an error if the path is empty" in {
+
+      val value = Json.obj()
+
+      value.set(JsPath, Json.obj()) mustEqual JsError("path cannot be empty")
+    }
+
+
+    "must return Json unchanged if the path does not contain a value" in {
+
+      val originalKey = nonEmptyAlphaStr
+      val originalValue = nonEmptyAlphaStr
+      val pathKey = nonEmptyAlphaStr2
+      val value = Json.obj(originalKey -> originalValue)
+
+      val path = JsPath \ pathKey
+
+      value.remove(path) mustEqual JsSuccess(value)
+    }
+
+    "must remove a value given a keyPathNode and return the new object" in {
+      val keys = Seq(nonEmptyAlphaStr, nonEmptyAlphaStr2)
+      val values = Seq(nonEmptyAlphaStr3, nonEmptyAlphaStr3)
+      val keyToRemove = nonEmptyAlphaStr3
+      val valueToRemove = nonEmptyAlphaStr3
+
+      val initialObj: JsObject = keys.zip(values).foldLeft(JsObject.empty) {
+        case (acc, (key, value)) => acc + (key -> JsString(value))
+      }
+
+      val testObject: JsObject = initialObj + (keyToRemove -> Json.toJson(valueToRemove))
+
+      val pathToRemove = JsPath \ keyToRemove
+
+      testObject mustNot equal(initialObj)
+      testObject.remove(pathToRemove) mustEqual JsSuccess(initialObj)
+    }
+
+    "must remove a value given an index node and return the new object for one array" in {
+      val key = nonEmptyAlphaStr
+      val values = Seq(nonEmptyAlphaStr2, nonEmptyAlphaStr3)
+      val indexToRemove = 0
+
+      val valuesInArrays: Seq[JsValue] = values.map(Json.toJson[String])
+      val initialObj: JsObject = buildJsObj(Seq(key), Seq(valuesInArrays))
+
+      val pathToRemove = JsPath \ key \ indexToRemove
+
+      val removed: JsResult[JsValue] = initialObj.remove(pathToRemove)
+
+
+      val expectedOutcome =
+        buildJsObj(
+          Seq(key),
+          Seq(valuesInArrays.slice(0, indexToRemove) ++ valuesInArrays.slice(indexToRemove + 1, values.length)
+          )
+        )
+
+      removed mustBe JsSuccess(expectedOutcome)
+    }
+
+    "remove a value from one of many arrays" in {
+
+      val input = Json.obj(
+        "key" -> JsArray(Seq(Json.toJson(1), Json.toJson(2))),
+        "key2" -> JsArray(Seq(Json.toJson(1), Json.toJson(2)))
+      )
+
+      val path = JsPath \ "key" \ 0
+
+      input.remove(path) mustBe JsSuccess(
+        Json.obj(
+          "key" -> JsArray(Seq(Json.toJson(2))), "key2" -> JsArray(Seq(Json.toJson(1), Json.toJson(2))))
+      )
+    }
+  }
+
+  "remove a value when there are nested arrays" in {
+
+    val input = Json.obj(
+      "key" -> JsArray(Seq(JsArray(Seq(Json.toJson(1), Json.toJson(2))), Json.toJson(2))),
+      "key2" -> JsArray(Seq(Json.toJson(1), Json.toJson(2)))
+    )
+
+    val path = JsPath \ "key" \ 0 \ 0
+
+    input.remove(path) mustBe JsSuccess(
+      Json.obj(
+        "key" -> JsArray(Seq(JsArray(Seq(Json.toJson(2))), Json.toJson(2))),
+        "key2" -> JsArray(Seq(Json.toJson(1), Json.toJson(2)))
+      )
+    )
+  }
+
+  "remove the value if the last value is deleted from an array" in {
+    val input = Json.obj(
+      "key" -> JsArray(Seq(Json.toJson(1))),
+      "key2" -> JsArray(Seq(Json.toJson(1), Json.toJson(2)))
+    )
+
+    val path = JsPath \ "key" \ 0
+
+    input.remove(path) mustBe JsSuccess(
+      Json.obj(
+        "key" -> JsArray(),
+        "key2" -> JsArray(Seq(Json.toJson(1), Json.toJson(2)))
+      )
+    )
+  }
+
+  "NOT remove delete last value when value given doesn't match value in array" in {
+    val input = Json.obj(
+      "key" -> JsArray(Seq(Json.obj("key2" -> 1)))
+    )
+
+    val path = JsPath \ "key" \ 0 \ "key3"
+
+    input.remove(path) mustBe JsSuccess(
+      Json.obj(
+        "key" -> JsArray(Seq(Json.obj("key2" -> 1)))
+      )
+    )
+  }
+}

--- a/test/navigation/FakeNavigators.scala
+++ b/test/navigation/FakeNavigators.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package navigation
+
+import models.{Mode, UserAnswers}
+import pages._
+import play.api.mvc.Call
+
+object FakeNavigators {
+
+  class FakeNavigator(desiredRoute: Call) extends BaseNavigator {
+    override def nextPage(page: Page, mode: Mode, userAnswers: UserAnswers): Call =
+      desiredRoute
+  }
+}

--- a/test/services/PreValidateTraderUserAnswersServiceSpec.scala
+++ b/test/services/PreValidateTraderUserAnswersServiceSpec.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services
+
+import repositories.PreValidateTraderUserAnswersRepository
+
+class PreValidateTraderUserAnswersServiceSpec extends BaseUserAnswersServiceSpec {
+
+  override lazy val repository: PreValidateTraderUserAnswersRepository = new PreValidateTraderUserAnswersRepository(appConfig)(
+    mongoComponent = mongoComponent,
+    time = timeMachine,
+    ec = ec
+  )
+
+  override lazy val service: PreValidateTraderUserAnswersService = new PreValidateTraderUserAnswersService(repository)
+}


### PR DESCRIPTION
Includes some Base traits which are then provided with some concrete implementations for PreValidate variants.

Has a new Controller predicate to create a new `UserAnswersRequest` as this has to be used instead of the `DataRequest` mainly, because DataRequest is already being used elsewhere and it can't retrieve the PreValidate User Answers as part of that.

It's been implemented in a way that would make it easy to extend this with another UserAnswers collection which could share the same underlying base methods. So, if we ever put another frontend journey into this it would be relatively straigtforward.

