### PR TITLE
[ETFE-3782] - Fix [draft] movement links by removing padding

### DIFF
--- a/app/controllers/drafts/ViewAllDraftMovementsController.scala
+++ b/app/controllers/drafts/ViewAllDraftMovementsController.scala
@@ -26,8 +26,8 @@ import forms.ViewAllDraftMovementsFormProvider
 import models.draftMovements.GetDraftMovementsSearchOptions.DEFAULT_MAX_ROWS
 import models.draftMovements.{DraftMovementSortingSelectOption, GetDraftMovementsSearchOptions}
 import models.requests.DataRequest
+import models.response.ErrorResponse
 import models.response.emcsTfe.draftMovement.GetDraftMovementsResponse
-import models.response.{ErrorResponse, NotFoundError}
 import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents, Result}

--- a/app/models/draftMovements/GetDraftMovementsSearchOptions.scala
+++ b/app/models/draftMovements/GetDraftMovementsSearchOptions.scala
@@ -168,7 +168,7 @@ object GetDraftMovementsSearchOptions extends Logging {
       options.destinationTypes.fold[Set[DestinationTypeSearchOption]](Set.empty)(_.toSet),
       options.exciseProductCode,
       options.dateOfDispatchFrom,
-      options.dateOfDispatchTo,
+      options.dateOfDispatchTo
     )
   )
 }

--- a/app/views/viewAllDrafts/DraftMovementsTableRowContent.scala.html
+++ b/app/views/viewAllDrafts/DraftMovementsTableRowContent.scala.html
@@ -30,11 +30,11 @@
 
 <div class="inbox">
     <div>
-        <h2 class="govuk-heading-m govuk-!-margin-bottom-0">
+        <h2 class="govuk-heading-m">
             @link(
                 link = appConfig.emcsTfeCreateMovementTaskListUrl(ern, movement.draftId),
                 messageKey = movement.data.lrn,
-                classes = "govuk-heading-m govuk-link"
+                classes = "govuk-link"
             )
         </h2>
 
@@ -49,9 +49,9 @@
 
         @p(){
             @if(movement.hasErrors) {
-                @{govukTag(TagViewModel(Text(messages("viewAllDraftMovements.status.error"))).red())}
+                @govukTag(TagViewModel(Text(messages("viewAllDraftMovements.status.error"))).red())
             }
-            @{govukTag(TagViewModel(Text(messages("viewAllDraftMovements.status.draft"))).grey())}
+            @govukTag(TagViewModel(Text(messages("viewAllDraftMovements.status.draft"))).grey())
         }
         @p("govuk-body-s"){
             @messages("viewAllDraftMovements.lastUpdated", movement.lastUpdated.formatDateForUIOutput())

--- a/app/views/viewAllDrafts/DraftMovementsTableRowContent.scala.html
+++ b/app/views/viewAllDrafts/DraftMovementsTableRowContent.scala.html
@@ -33,8 +33,7 @@
         <h2 class="govuk-heading-m">
             @link(
                 link = appConfig.emcsTfeCreateMovementTaskListUrl(ern, movement.draftId),
-                messageKey = movement.data.lrn,
-                classes = "govuk-link"
+                messageKey = movement.data.lrn
             )
         </h2>
 

--- a/app/views/viewAllMovements/MovementTableRowContent.scala.html
+++ b/app/views/viewAllMovements/MovementTableRowContent.scala.html
@@ -28,8 +28,7 @@
 <h2 class="govuk-heading-m">
     @link(
         link = movement.viewMovementUrl(ern).url,
-        messageKey = movement.arc,
-        classes = "govuk-link"
+        messageKey = movement.arc
     )
 </h2>
 

--- a/app/views/viewAllMovements/MovementTableRowContent.scala.html
+++ b/app/views/viewAllMovements/MovementTableRowContent.scala.html
@@ -25,11 +25,11 @@
 
 @(ern: String, movement: GetMovementListItem, directionFilterOption: MovementFilterDirectionOption)(implicit messages: Messages)
 
-<h2 class="govuk-!-margin-bottom-0">
+<h2 class="govuk-heading-m">
     @link(
         link = movement.viewMovementUrl(ern).url,
         messageKey = movement.arc,
-        classes = "govuk-heading-m govuk-link"
+        classes = "govuk-link"
     )
 </h2>
 


### PR DESCRIPTION
Before:

![image](https://github.com/hmrc/emcs-tfe-frontend/assets/53828896/ed4e5b3d-baad-4bd0-b246-1dfd72be7704)

After:
![image](https://github.com/hmrc/emcs-tfe-frontend/assets/53828896/27e63645-0c2b-492a-9df4-a2d6448f4a78)

(also applied on draft movements page)