### PR TITLE
ETFE-3932 EVN-02: Update to movement

### DIFF
--- a/app/controllers/events/ViewEventController.scala
+++ b/app/controllers/events/ViewEventController.scala
@@ -48,6 +48,13 @@ class ViewEventController @Inject()(mcc: MessagesControllerComponents,
     with Logging
     with BetaChecks {
 
+  def movementCreated(ern: String, arc: String, eventId: Int): Action[AnyContent] =
+    onPageLoad(ern, arc, eventId, IE801)
+
+  def movementUpdated(ern: String, arc: String, eventId: Int): Action[AnyContent] =
+    onPageLoad(ern, arc, eventId, IE801)
+
+
   private def onPageLoad(ern: String, arc: String, eventId: Int, eventType: EventTypes): Action[AnyContent] = {
     authorisedDataRequestAsync(ern, viewMovementBetaGuard(ern, arc)) { implicit request =>
       withHistoryEvent(ern, arc, eventType, eventId) { event =>
@@ -59,9 +66,6 @@ class ViewEventController @Inject()(mcc: MessagesControllerComponents,
     }
   }
 
-  def movementCreated(ern: String, arc: String, eventId: Int): Action[AnyContent] = {
-    onPageLoad(ern, arc, eventId, IE801)
-  }
 
   private def withHistoryEvent(ern:String, arc: String, eventType: EventTypes, eventId: Int)
                       (f: MovementHistoryEvent => Future[Result])(implicit request: DataRequest[_]): Future[Result] =

--- a/app/models/response/emcsTfe/GetMovementResponse.scala
+++ b/app/models/response/emcsTfe/GetMovementResponse.scala
@@ -103,7 +103,7 @@ object GetMovementResponse {
     numberOfItems <- (__ \ "numberOfItems").read[Int]
     reportOfReceipt <- (__ \ "reportOfReceipt").readNullable[ReportOfReceiptModel]
     items <- (__ \ "items").read[Seq[MovementItem]]
-    eventHistorySummary <- (__ \ "eventHistorySummary").readNullable[Seq[MovementHistoryEvent]]
+    eventHistorySummary <- (__ \ "eventHistorySummary").readNullable[Seq[MovementHistoryEvent]](MovementHistoryEvent.seqReads)
   } yield {
     GetMovementResponse(
       arc = arc,

--- a/app/viewmodels/TimelineEvent.scala
+++ b/app/viewmodels/TimelineEvent.scala
@@ -20,4 +20,6 @@ import models.EventTypes
 
 import java.time.LocalDateTime
 
-case class TimelineEvent(eventType: EventTypes, title: String, dateTime: LocalDateTime, url: String)
+case class TimelineEvent(eventType: EventTypes, title: String, dateTime: LocalDateTime, url: String) {
+  val id: String = title.replace(" ", "-").toLowerCase
+}

--- a/app/viewmodels/helpers/ItemDetailsCardHelper.scala
+++ b/app/viewmodels/helpers/ItemDetailsCardHelper.scala
@@ -191,7 +191,7 @@ class ItemDetailsCardHelper @Inject()(list: list, link: link, appConfig: AppConf
       item.unitOfMeasure.map { unitOfMeasure =>
         summaryListRowBuilder(
           messages("itemDetails.key.density"),
-          messages("itemDetails.value.density", density.toString(), messages(s"itemDetails.value.density.$unitOfMeasure"))
+          Html(messages("itemDetails.value.density", density.toString(), messages(s"itemDetails.value.density.$unitOfMeasure")))
         )
       }
     }

--- a/app/viewmodels/helpers/TimelineHelper.scala
+++ b/app/viewmodels/helpers/TimelineHelper.scala
@@ -47,18 +47,21 @@ class TimelineHelper @Inject()() extends Logging {
     s"${getEventBaseKey(event)}.urlLabel"
 
   def getEventBaseKey(event: MovementHistoryEvent): String = {
-    (event.eventType, event.sequenceNumber, event.messageRole) match {
-      case (IE801, 1, 0) => s"movementHistoryEvent.${event.eventType}.first"
-      case (IE801, _, 0) => s"movementHistoryEvent.${event.eventType}.further"
-      case (IE802, _, 1) => s"movementHistoryEvent.${event.eventType}.cod"
-      case (IE802, _, 2) => s"movementHistoryEvent.${event.eventType}.ror"
-      case (IE802, _, 3) => s"movementHistoryEvent.${event.eventType}.des"
-      case (IE803, _, 1) => s"movementHistoryEvent.${event.eventType}.diverted"
-      case (IE803, _, 2) => s"movementHistoryEvent.${event.eventType}.split"
-      case (IE840, _, 1) => s"movementHistoryEvent.${event.eventType}.first"
-      case (IE840, _, 2) => s"movementHistoryEvent.${event.eventType}.complementary"
-      case _ => s"movementHistoryEvent.${event.eventType}"
+    val base = s"movementHistoryEvent.${event.eventType}"
+
+    val suffix = (event.eventType, event.messageRole) match {
+      case (IE801, 0) => if (event.isFirstEventTypeInHistory) "first" else "further"
+      case (IE802, 1) => "cod"
+      case (IE802, 2) => "ror"
+      case (IE802, 3) => "des"
+      case (IE803, 1) => "diverted"
+      case (IE803, 2) => "split"
+      case (IE840, 1) => "first"
+      case (IE840, 2) => "complementary"
+      case _ => ""
     }
+
+    if (suffix.isEmpty) base else s"$base.$suffix"
   }
 
   def parseDateTime(eventDate: String): LocalDateTime = {

--- a/app/viewmodels/helpers/events/EventsHelper.scala
+++ b/app/viewmodels/helpers/events/EventsHelper.scala
@@ -73,7 +73,7 @@ class EventsHelper @Inject()(
     p(classes = "govuk-body no-print")(
       HtmlFormat.fill(
         Seq(
-          link(classes = "govuk-link", link ="javascript:if(window.print)window.print()", id = Some("print-page"), messageKey=linkContentKey),
+          link(classes = "govuk-link", link ="javascript:if(window.print)window.print()", id = Some("print-link"), messageKey=linkContentKey),
           Html(messages(linkTrailingMessageKey))
         )
       )

--- a/app/viewmodels/helpers/events/EventsHelper.scala
+++ b/app/viewmodels/helpers/events/EventsHelper.scala
@@ -35,18 +35,18 @@ class EventsHelper @Inject()(
 
   def constructEventInformation(event: MovementHistoryEvent, movement: GetMovementResponse)(implicit messages: Messages): Html = {
     event.eventType match {
-      case IE801  => movementCards(event, movement)
+      case IE801  => ie801Html(event, movement)
       case _      => Empty.asHtml
     }
   }
 
-  private def movementCards(event: MovementHistoryEvent, movement: GetMovementResponse)(implicit messages: Messages): Html = {
+  private def ie801Html(event: MovementHistoryEvent, movement: GetMovementResponse)(implicit messages: Messages): Html = {
     implicit val _movement: GetMovementResponse = movement
 
     HtmlFormat.fill(
       Seq(
         p(classes = "govuk-body-l")(Html(
-            messages(s"${timelineHelper.getEventBaseKey(event)}.p1")
+            messages(s"${timelineHelper.getEventBaseKey(event)}.p1", event.sequenceNumber)
         )),
         printPage(linkContentKey = "movementHistoryEvent.printLink", linkTrailingMessageKey = "movementHistoryEvent.printMessage"),
         eventHelper.movementInformationCard(),

--- a/app/viewmodels/helpers/events/MovementEventHelper.scala
+++ b/app/viewmodels/helpers/events/MovementEventHelper.scala
@@ -396,6 +396,7 @@ class MovementEventHelper @Inject()(
       Details(
         summary = Text(messages("movementCreatedView.section.item.viewAllInformation", index + 1)),
         classes = "govuk-details govuk-!-margin-bottom-2",
+        id = Some(s"item-information-details-${index + 1}"),
         content = HtmlContent(
           buildOverviewPartial(
             summaryListRows = Seq(
@@ -430,6 +431,7 @@ class MovementEventHelper @Inject()(
       Details(
         summary = Text(messages("movementCreatedView.section.item.viewAllPackagingInformation", index + 1)),
         classes = "govuk-details govuk-!-margin-top-2",
+        id = Some(s"item-packaging-details-${index + 1}"),
         content =
           HtmlContent(
             HtmlFormat.fill(

--- a/app/views/components/timeline.scala.html
+++ b/app/views/components/timeline.scala.html
@@ -27,7 +27,7 @@
     <li class="hmrc-timeline__event">
 
         <h3 class="hmrc-timeline__event-title govuk-heading-s">
-            @link(link = timelineEvent.url, messageKey = timelineEvent.title, id = Some(s"history-event-$index"))
+            @link(link = timelineEvent.url, messageKey = timelineEvent.title, id = Some(s"${timelineEvent.id}"))
         </h3>
 
         <time class="hmrc-timeline__event-meta" datetime="@{ISO_LOCAL_DATE_TIME.format(timelineEvent.dateTime)}">

--- a/conf/events.routes
+++ b/conf/events.routes
@@ -1,5 +1,5 @@
 GET        /trader/:ern/movement/:arc/event/:eventId/movement-created                        controllers.events.ViewEventController.movementCreated(ern: String, arc: String, eventId: Int)
-#GET        /trader/:ern/movement/:arc/event/:eventId/movement-updated                        controllers.events.ViewEventController.movementUpdated(ern: String, arc: String, eventId: Int)
+GET        /trader/:ern/movement/:arc/event/:eventId/movement-updated                        controllers.events.ViewEventController.movementUpdated(ern: String, arc: String, eventId: Int)
 #GET        /trader/:ern/movement/:arc/event/:eventId/change-destination-due                  controllers.events.ViewEventController.changeDestinationDue(ern: String, arc: String, eventId: Int)
 #GET        /trader/:ern/movement/:arc/event/:eventId/report-receipt-due                      controllers.events.ViewEventController.reportReceiptDue(ern: String, arc: String, eventId: Int)
 #GET        /trader/:ern/movement/:arc/event/:eventId/report-receipt-due                      controllers.events.ViewEventController.reportReceiptDue(ern: String, arc: String, eventId: Int)

--- a/conf/messages
+++ b/conf/messages
@@ -220,6 +220,7 @@ movementHistoryEvent.IE801.first.urlLabel = movement-created
 movementHistoryEvent.IE801.first.p1 = This is the first notification for the movement.
 movementHistoryEvent.IE801.further.label = Update to movement
 movementHistoryEvent.IE801.further.urlLabel = movement-updated
+movementHistoryEvent.IE801.further.p1 = This movement has been updated. This is version {0} of the movement.
 movementHistoryEvent.IE802.cod.label = Reminder to provide change of destination
 movementHistoryEvent.IE802.cod.urlLabel = change-destination-due
 movementHistoryEvent.IE802.ror.label = Report of receipt due

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.7
+sbt.version=1.9.9

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@ resolvers += MavenRepository("HMRC-open-artefacts-maven2", "https://open.artefac
 resolvers += Resolver.url("HMRC-open-artefacts-ivy2", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
 resolvers += Resolver.typesafeRepo("releases")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build"     % "3.21.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build"     % "3.22.0")
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.5.0")
 
 addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.2")

--- a/test-utils/fixtures/GetMovementHistoryEventsResponseFixtures.scala
+++ b/test-utils/fixtures/GetMovementHistoryEventsResponseFixtures.scala
@@ -28,21 +28,24 @@ trait GetMovementHistoryEventsResponseFixtures { _: BaseFixtures =>
       eventDate = "2023-12-01T15:00:00",
       sequenceNumber = 1,
       messageRole = 1,
-      upstreamArc = Some(testArc)
+      upstreamArc = Some(testArc),
+      isFirstEventTypeInHistory = true
     ),
     MovementHistoryEvent(
       eventType = IE813,
       eventDate = "2023-12-02T13:00:00",
       sequenceNumber = 2,
       messageRole = 1,
-      upstreamArc = Some(testArc)
+      upstreamArc = Some(testArc),
+      isFirstEventTypeInHistory = false
     ),
     MovementHistoryEvent(
       eventType = IE818,
       eventDate = "2023-12-04T08:00:00",
       sequenceNumber = 3,
       messageRole = 1,
-      upstreamArc = Some(testArc)
+      upstreamArc = Some(testArc),
+      isFirstEventTypeInHistory = true
     )
   )
 
@@ -75,6 +78,7 @@ trait GetMovementHistoryEventsResponseFixtures { _: BaseFixtures =>
     eventDate = "2024-12-04T17:00:00", // hash code then bit shifted right = 853932155
     sequenceNumber = 1,
     messageRole = 0,
-    upstreamArc = None
+    upstreamArc = None,
+    isFirstEventTypeInHistory = true
   )
 }

--- a/test/controllers/events/ViewEventControllerSpec.scala
+++ b/test/controllers/events/ViewEventControllerSpec.scala
@@ -76,7 +76,8 @@ class ViewEventControllerSpec
         eventDate = "2024-12-04T17:00:00", // hash code then bit shifted right = 853932155
         sequenceNumber = 1,
         messageRole = 0,
-        upstreamArc = None
+        upstreamArc = None,
+        isFirstEventTypeInHistory = true
       )
 
       "render a view" in new Test {

--- a/test/viewmodels/TimelineEventSpec.scala
+++ b/test/viewmodels/TimelineEventSpec.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package viewmodels
+
+import models.EventTypes
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.time.LocalDateTime
+
+class TimelineEventSpec extends AnyFlatSpec with Matchers {
+
+  "id" should "replace spaces with dashes and convert to lowercase" in {
+    val event = TimelineEvent(EventTypes.IE801, "Test Title", LocalDateTime.now(), "/test/url")
+    event.id should be ("test-title")
+  }
+
+  it should "handle titles with no spaces" in {
+    val event = TimelineEvent(EventTypes.IE801, "TestTitle", LocalDateTime.now(), "/test/url")
+    event.id should be ("testtitle")
+  }
+
+  it should "handle empty titles" in {
+    val event = TimelineEvent(EventTypes.IE801, "", LocalDateTime.now(), "/test/url")
+    event.id should be ("")
+  }
+
+  it should "handle titles with multiple consecutive spaces" in {
+    val event = TimelineEvent(EventTypes.IE801, "Test  Title", LocalDateTime.now(), "/test/url")
+    event.id should be ("test--title")
+  }
+
+  it should "handle titles with multiple words" in {
+    val event = TimelineEvent(EventTypes.IE801, "Test this title", LocalDateTime.now(), "/test/url")
+    event.id should be ("test-this-title")
+  }
+}

--- a/test/viewmodels/helpers/ItemDetailsCardHelperSpec.scala
+++ b/test/viewmodels/helpers/ItemDetailsCardHelperSpec.scala
@@ -92,7 +92,7 @@ class ItemDetailsCardHelperSpec extends SpecBase with ItemFixtures {
               )),
               Seq(summaryListRowBuilder(
                 Text(langMessages.densityKey),
-                Text(langMessages.densityValue(item.density.get))
+                HtmlContent(langMessages.densityValue(item.density.get))
               )),
               Seq(summaryListRowBuilder(
                 Text(langMessages.alcoholicStrengthKey),

--- a/test/viewmodels/helpers/TimelineHelperSpec.scala
+++ b/test/viewmodels/helpers/TimelineHelperSpec.scala
@@ -64,20 +64,21 @@ class TimelineHelperSpec extends SpecBase {
   ".getEventTitleKey" must {
     "return the correct message key" when {
 
-      def getKey(eventType: EventTypes, sequenceNumber: Int, messageRole: Int):String = {
+      def getKey(eventType: EventTypes, sequenceNumber: Int, messageRole: Int, firstEventTypeInTimeline: Boolean = false):String = {
         helper.getEventTitleKey(
           MovementHistoryEvent(
             eventType = eventType,
             eventDate = "",
             sequenceNumber = sequenceNumber,
             messageRole = messageRole,
-            None
+            None,
+            isFirstEventTypeInHistory = firstEventTypeInTimeline
           )
         )
       }
 
       "the event is for a movement created" in {
-        getKey(IE801, 1, 0) mustBe "movementHistoryEvent.IE801.first.label"
+        getKey(IE801, 1, 0, firstEventTypeInTimeline = true) mustBe "movementHistoryEvent.IE801.first.label"
       }
       "the event is for an update to the movement" in {
         getKey(IE801, 2, 0) mustBe "movementHistoryEvent.IE801.further.label"
@@ -149,7 +150,8 @@ class TimelineHelperSpec extends SpecBase {
         eventDate = eventDate,
         sequenceNumber = 1,
         messageRole = 0,
-        upstreamArc = None
+        upstreamArc = None,
+        isFirstEventTypeInHistory = true
       )
 
       /*


### PR DESCRIPTION
- 1st commit address a long standing bug with regards to what a consignee sees when a movement is diverted to them. The movement history event is an IE801 but has a sequence number greater than 1. The bug is that it would show as "Update to Movement" when it should say "Movement Created". More details on this are on the JIRA ticket and this part can be tested with the data setup on https://github.com/hmrc/emcs-tfe-stub/pull/97.
- 2nd commit adds the ability for a user to see the updated movement when clicking on it from the movement history timeline view.