### PR TITLE
[ETFE-3980] - Notification of split movement event

### DIFF
--- a/app/assets/javascripts/app.js
+++ b/app/assets/javascripts/app.js
@@ -15,12 +15,6 @@ document.addEventListener('DOMContentLoaded', function(event) {
     });
   }
 
-  // handle print link visibility  click
-  const printPageContainer = document.querySelector('.print-page');
-  if (printPageContainer) {
-    printPageContainer.classList.remove('govuk-!-display-none'); //Remove the hide class from the link (JS enabled = show, JS disabled = hide)
-  }
-
   const printLink = document.getElementById('print-link');
 
   if (printLink) {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -81,3 +81,10 @@ $hmrc-assets-path: "/emcs/account/assets/lib/hmrc-frontend/hmrc/assets/";
   word-wrap: break-word;
 }
 
+.js-visible {
+  display: none !important;
+}
+.js-enabled .js-visible {
+  display: inline-block !important;
+}
+

--- a/app/viewmodels/helpers/events/EventsHelper.scala
+++ b/app/viewmodels/helpers/events/EventsHelper.scala
@@ -105,7 +105,7 @@ class EventsHelper @Inject()(
     )
 
   private def printPage(linkContentKey: String, linkTrailingMessageKey: String)(implicit messages: Messages): Html = {
-    p(classes = "govuk-body no-print govuk-!-display-none print-page")(
+    p(classes = "govuk-body no-print js-visible")(
       HtmlFormat.fill(
         Seq(
           link(classes = "govuk-link", link = "#", id = Some("print-link"), messageKey = linkContentKey),

--- a/app/viewmodels/helpers/messages/ViewMessageHelper.scala
+++ b/app/viewmodels/helpers/messages/ViewMessageHelper.scala
@@ -101,7 +101,7 @@ class ViewMessageHelper @Inject()(
       messageKey = "viewMessage.link.viewMovement.description", id = Some("view-movement")
     )
     lazy val printMessageLink: Html = link(
-      link = "#print-dialogue", messageKey = "viewMessage.link.printMessage.description", id = Some("print-link"), classes = "govuk-link print-page govuk-!-display-none"
+      link = "#print-dialogue", messageKey = "viewMessage.link.printMessage.description", id = Some("print-link"), classes = "govuk-link js-visible"
     )
     lazy val deleteMessageLink: Html = link(
       link = controllers.messages.routes.DeleteMessageController.onPageLoad(request.ern, message.uniqueMessageIdentifier).url,

--- a/test/viewmodels/helpers/messages/ViewMessageHelperSpec.scala
+++ b/test/viewmodels/helpers/messages/ViewMessageHelperSpec.scala
@@ -161,7 +161,7 @@ class ViewMessageHelperSpec extends SpecBase
                   link(
                     link = "#print-dialogue",
                     messageKey = "viewMessage.link.printMessage.description",
-                    classes = "govuk-link print-page govuk-!-display-none",
+                    classes = "govuk-link js-visible",
                     id = Some("print-link")
                   ),
                   link(
@@ -203,7 +203,7 @@ class ViewMessageHelperSpec extends SpecBase
                   link(
                     link = "#print-dialogue",
                     messageKey = "viewMessage.link.printMessage.description",
-                    classes = "govuk-link print-page govuk-!-display-none",
+                    classes = "govuk-link js-visible",
                     id = Some("print-link")
                   ),
                   link(
@@ -235,7 +235,7 @@ class ViewMessageHelperSpec extends SpecBase
                   link(
                     link = "#print-dialogue",
                     messageKey = "viewMessage.link.printMessage.description",
-                    classes = "govuk-link print-page govuk-!-display-none",
+                    classes = "govuk-link js-visible",
                     id = Some("print-link")
                   ),
                   link(
@@ -272,7 +272,7 @@ class ViewMessageHelperSpec extends SpecBase
                   link(
                     link = "#print-dialogue",
                     messageKey = "viewMessage.link.printMessage.description",
-                    classes = "govuk-link print-page govuk-!-display-none",
+                    classes = "govuk-link js-visible",
                     id = Some("print-link")
                   ),
                   link(
@@ -314,7 +314,7 @@ class ViewMessageHelperSpec extends SpecBase
                   link(
                     link = "#print-dialogue",
                     messageKey = "viewMessage.link.printMessage.description",
-                    classes = "govuk-link print-page govuk-!-display-none",
+                    classes = "govuk-link js-visible",
                     id = Some("print-link")
                   ),
                   link(
@@ -348,7 +348,7 @@ class ViewMessageHelperSpec extends SpecBase
                     link(
                       link = "#print-dialogue",
                       messageKey = "viewMessage.link.printMessage.description",
-                      classes = "govuk-link print-page govuk-!-display-none",
+                      classes = "govuk-link js-visible",
                       id = Some("print-link")
                     ),
                     link(
@@ -390,7 +390,7 @@ class ViewMessageHelperSpec extends SpecBase
                     link(
                       link = "#print-dialogue",
                       messageKey = "viewMessage.link.printMessage.description",
-                      classes = "govuk-link print-page govuk-!-display-none",
+                      classes = "govuk-link js-visible",
                       id = Some("print-link")
                     ),
                     link(
@@ -423,7 +423,7 @@ class ViewMessageHelperSpec extends SpecBase
                   link(
                     link = "#print-dialogue",
                     messageKey = "viewMessage.link.printMessage.description",
-                    classes = "govuk-link print-page govuk-!-display-none",
+                    classes = "govuk-link js-visible",
                     id = Some("print-link")
                   ),
                   link(
@@ -465,7 +465,7 @@ class ViewMessageHelperSpec extends SpecBase
                   link(
                     link = "#print-dialogue",
                     messageKey = "viewMessage.link.printMessage.description",
-                    classes = "govuk-link print-page govuk-!-display-none",
+                    classes = "govuk-link js-visible",
                     id = Some("print-link")
                   ),
                   link(
@@ -497,7 +497,7 @@ class ViewMessageHelperSpec extends SpecBase
                   link(
                     link = "#print-dialogue",
                     messageKey = "viewMessage.link.printMessage.description",
-                    classes = "govuk-link print-page govuk-!-display-none",
+                    classes = "govuk-link js-visible",
                     id = Some("print-link")
                   ),
                   link(
@@ -529,7 +529,7 @@ class ViewMessageHelperSpec extends SpecBase
                   link(
                     link = "#print-dialogue",
                     messageKey = "viewMessage.link.printMessage.description",
-                    classes = "govuk-link print-page govuk-!-display-none",
+                    classes = "govuk-link js-visible",
                     id = Some("print-link")
                   ),
                   link(
@@ -561,7 +561,7 @@ class ViewMessageHelperSpec extends SpecBase
                   link(
                     link = "#print-dialogue",
                     messageKey = "viewMessage.link.printMessage.description",
-                    classes = "govuk-link print-page govuk-!-display-none",
+                    classes = "govuk-link js-visible",
                     id = Some("print-link")
                   ),
                   link(
@@ -598,7 +598,7 @@ class ViewMessageHelperSpec extends SpecBase
                   link(
                     link = "#print-dialogue",
                     messageKey = "viewMessage.link.printMessage.description",
-                    classes = "govuk-link print-page govuk-!-display-none",
+                    classes = "govuk-link js-visible",
                     id = Some("print-link")
                   ),
                   link(
@@ -630,7 +630,7 @@ class ViewMessageHelperSpec extends SpecBase
                   link(
                     link = "#print-dialogue",
                     messageKey = "viewMessage.link.printMessage.description",
-                    classes = "govuk-link print-page govuk-!-display-none",
+                    classes = "govuk-link js-visible",
                     id = Some("print-link")
                   ),
                   link(


### PR DESCRIPTION
Fixes issue where print link would show on messages and movement history events despite JS being disabled. Also cleanup some JS code.