### PR TITLE
[ETFE-4360] Remove transform as play encodes queryString anyway

### DIFF
--- a/app/forms/ViewAllDraftMovementsFormProvider.scala
+++ b/app/forms/ViewAllDraftMovementsFormProvider.scala
@@ -30,9 +30,7 @@ class ViewAllDraftMovementsFormProvider @Inject() extends Mappings {
     Form(
       mapping(
         ViewAllDraftMovementsFormProvider.sortByKey -> text().transform[String](removeAnyNonAlphanumerics, identity),
-        ViewAllDraftMovementsFormProvider.searchValue ->
-          optional(playText().verifying(regexpUnlessEmpty(XSS_REGEX, "error.invalidCharacter")))
-            .transform[Option[String]](_.map(removeAnyQueryParamCharacters), identity),
+        ViewAllDraftMovementsFormProvider.searchValue -> optional(playText().verifying(regexpUnlessEmpty(XSS_REGEX, "error.invalidCharacter"))),
         ViewAllDraftMovementsFormProvider.draftHasErrors -> set(enumerable[DraftMovementsErrorsOption]()),
         ViewAllDraftMovementsFormProvider.destinationTypes -> set(enumerable[DestinationTypeSearchOption]()),
         ViewAllDraftMovementsFormProvider.exciseProductCode -> optional(text()).transform[Option[String]](_.map(removeAnyNonAlphanumerics), identity),

--- a/app/forms/ViewAllMovementsFormProvider.scala
+++ b/app/forms/ViewAllMovementsFormProvider.scala
@@ -29,9 +29,7 @@ class ViewAllMovementsFormProvider @Inject() extends Mappings {
     Form(
       mapping(
         ViewAllMovementsFormProvider.searchKey -> optional(playText()).transform[Option[String]](_.map(removeAnyNonAlphanumerics), identity),
-        ViewAllMovementsFormProvider.searchValue ->
-          optional(playText().verifying(regexpUnlessEmpty(XSS_REGEX, "error.invalidCharacter")))
-            .transform[Option[String]](_.map(removeAnyQueryParamCharacters), identity),
+        ViewAllMovementsFormProvider.searchValue -> optional(playText().verifying(regexpUnlessEmpty(XSS_REGEX, "error.invalidCharacter"))),
         ViewAllMovementsFormProvider.sortBy -> enumerable[MovementSortingSelectOption](),
         ViewAllMovementsFormProvider.traderRole -> set(enumerable[MovementFilterDirectionOption]()),
         ViewAllMovementsFormProvider.undischarged -> set(enumerable[MovementFilterUndischargedOption]()),

--- a/app/forms/package.scala
+++ b/app/forms/package.scala
@@ -20,12 +20,6 @@ package object forms {
   private[forms] val EXCISE_NUMBER_REGEX = "[A-Z]{2}[a-zA-Z0-9]{11}"
 
   /**
-   * When form values will be used as query parameters, we will need to silently guard against users entering `&` or `/` for example,
-   * this function will replace any non-alphanumeric with a blank value e.g. `value&unexpected/ parameter` -> `valueunexpected parameter`
-   */
-  private[forms] def removeAnyQueryParamCharacters(rawString: String): String = rawString.trim.replaceAll("[/&?=]", "")
-
-  /**
    * A more strict variant of `removeAnyQueryParamCharacters` that will remove all non-alphanumeric characters
    */
   private[forms] def removeAnyNonAlphanumerics(rawString: String): String = rawString.trim.replaceAll("[^A-Za-z0-9]", "")

--- a/test/forms/ViewAllDraftMovementsFormProviderSpec.scala
+++ b/test/forms/ViewAllDraftMovementsFormProviderSpec.scala
@@ -87,14 +87,6 @@ class ViewAllDraftMovementsFormProviderSpec extends SpecBase {
       actualResult mustBe expectedResult
     }
 
-    "remove any non-query-params from the form values" in {
-      val boundForm = form.bind(Map(
-        sortByKey -> DraftMovementSortingSelectOption.Newest.code,
-        searchValue -> "ARC1/injecting viruses?query=thing&beans",
-      ))
-      boundForm.get mustBe GetDraftMovementsSearchOptions(searchValue = Some("ARC1injecting virusesquerythingbeans"))
-    }
-
     "return an error when the value is invalid" in {
       val boundForm = form.bind(Map(
         sortByKey -> DraftMovementSortingSelectOption.Newest.code,

--- a/test/forms/ViewAllMovementsFormProviderSpec.scala
+++ b/test/forms/ViewAllMovementsFormProviderSpec.scala
@@ -92,14 +92,6 @@ class ViewAllMovementsFormProviderSpec extends SpecBase {
       boundForm.get mustBe MovementListSearchOptions(searchValue = Some("beans"))
     }
 
-    "remove any non-query-params from the form values" in {
-      val boundForm = form.bind(Map(
-        searchValue -> "ARC1/injecting viruses?query=thing&beans",
-        sortBy -> Newest.code
-      ))
-      boundForm.get mustBe MovementListSearchOptions(searchValue = Some("ARC1injecting virusesquerythingbeans"))
-    }
-
     "return an error when the value is invalid" in {
       val boundForm = form.bind(Map(
         searchValue -> "<script>alert('hi')</script>",

--- a/test/forms/packageSpec.scala
+++ b/test/forms/packageSpec.scala
@@ -20,18 +20,6 @@ import base.SpecBase
 
 class packageSpec extends SpecBase {
 
-  "removeAnyQueryParamCharacters" must {
-    "remove any query param characters" in {
-      removeAnyQueryParamCharacters("value&unexpected/ parameter2") mustBe "valueunexpected parameter2"
-    }
-    "trim leading and trailing whitespace" in {
-      removeAnyQueryParamCharacters(" value&unexpected/ parameter2 ") mustBe "valueunexpected parameter2"
-    }
-    "not remove alphanumeric characters" in {
-      removeAnyQueryParamCharacters("valueunexpected123 parameter") mustBe "valueunexpected123 parameter"
-    }
-  }
-
   "removeAnyNonAlphanumerics" must {
     "remove any non-alphanumeric characters" in {
       removeAnyNonAlphanumerics("value&unexpected/ parameter2") mustBe "valueunexpectedparameter2"


### PR DESCRIPTION
- Tested locally
- This is to solve an issue a User has in live where they can't search for their movement because the LRN as a `/` in it. E.g. `00123/01`