### PR TITLE
ETFE-4543 Fix missing content for IE802, mesageRole=1

### DIFF
--- a/app/viewmodels/helpers/messages/ViewMessageHelper.scala
+++ b/app/viewmodels/helpers/messages/ViewMessageHelper.scala
@@ -72,7 +72,7 @@ class ViewMessageHelper @Inject()(
     messagesHelper.additionalInformationKey(message) -> message.messageType match {
       case Some(_) -> "IE871" if movement.exists(!_.isBeingViewedByConsignee) =>
         Empty.asHtml
-      case Some(key) -> "IE802" if movement.exists(_.isBeingViewedByConsignor) =>
+      case Some(key) -> "IE802" if (movement.exists(_.isBeingViewedByConsignor) && message.messageRole == 2) =>
         p() { Html(messages(key + ".consignor")) }
       case Some(key) -> _ =>
         p() { Html(messages(key)) }

--- a/conf/messages
+++ b/conf/messages
@@ -916,7 +916,7 @@ messages.IE801.false.0.paragraph = There is a new movement on its way to you.
 messages.IE801.true.0.description = New movement submitted successfully
 
 messages.IE802.false.1.description = Reminder to change destination
-messages.IE802.false.1.paragraph = This movement requires a change of destination.
+messages.IE802.false.1.paragraph = You need to submit a change of destination for this movement because the consignee has either rejected, refused or partially refused the goods.
 messages.IE802.false.2.description = Reminder for report of receipt
 messages.IE802.false.2.paragraph = You have received a movement but we have not yet received your Report of Receipt. However if you have sent a Report of Receipt within the last 7 days, please ignore this reminder.
 messages.IE802.false.2.paragraph.consignor = The consignee has not yet submitted a report of receipt for this movement.

--- a/test/views/messages/ViewMessageViewSpec.scala
+++ b/test/views/messages/ViewMessageViewSpec.scala
@@ -465,9 +465,17 @@ class ViewMessageViewSpec extends ViewSpecBase
     }
   }
 
-  s"when an IE802 reminder to change destination" should {
+  // Only consignors get an IE802 with a message role of 1, consignees will never get this reminder
+  s"when an IE802 reminder to change destination is viewed by the consignor" should {
     "contain other information" when {
-      implicit val doc: Document = asDocument(ie802ReminderToChangeDestination.message)
+      val movementWithLoggedInUserAsConsignor = Some(getMovementResponseModel
+        .copy(
+          consignorTrader = getMovementResponseModel.consignorTrader.copy(traderExciseNumber = Some(testErn)),
+          consigneeTrader = getMovementResponseModel.consigneeTrader.map(_.copy(traderExciseNumber = Some("GB00000000000")))
+        )
+      )
+
+      implicit val doc: Document = asDocument(ie802ReminderToChangeDestination.message, optMovement = movementWithLoggedInUserAsConsignor)
 
       behave like pageWithExpectedElementsAndMessages(
         Seq(
@@ -477,7 +485,7 @@ class ViewMessageViewSpec extends ViewSpecBase
     }
   }
 
-  s"when an IE802 reminder to receipt" should {
+  s"when an IE802 reminder to receipt is viewed by consignee" should {
     "contain other information" when {
       implicit val doc: Document = asDocument(ie802ReminderToReportReceipt.message)
 

--- a/test/views/messages/ViewMessageViewSpec.scala
+++ b/test/views/messages/ViewMessageViewSpec.scala
@@ -479,7 +479,7 @@ class ViewMessageViewSpec extends ViewSpecBase
 
       behave like pageWithExpectedElementsAndMessages(
         Seq(
-          Selectors.p(1) -> "This movement requires a change of destination."
+          Selectors.p(1) -> "You need to submit a change of destination for this movement because the consignee has either rejected, refused or partially refused the goods."
         )
       )
     }


### PR DESCRIPTION
AN IE802 message role of 1 is a message sent only to the consignor and is a reminder message to change the destination.