### PR TITLE
ETFE-4211 [AccPreAudit4][P1] - Console errors - Correct use of autocomplete

### DIFF
--- a/app/views/prevalidateTrader/PrevalidateExciseProductCodeView.scala.html
+++ b/app/views/prevalidateTrader/PrevalidateExciseProductCodeView.scala.html
@@ -36,10 +36,6 @@
 
 @(form: Form[_], action: Call, selectOptions: Seq[SelectItem], indexOfDocument: Index)(implicit request: UserAnswersRequest[_], messages: Messages)
 
-@scripts = {
-    @autocompleteJavascript()
-}
-
 @errorMessage = @{
     form.errors("excise-product-code") match {
         case Nil => None
@@ -51,7 +47,7 @@
     pageTitle = title(form, messages("prevalidateTrader.exciseProductCode.title", indexOfDocument.displayIndex)),
     maybeShowActiveTrader = maybeShowActiveTrader(request.request),
     additionalCss = autocompleteCss(),
-    additionalScripts = scripts,
+    additionalScripts = autocompleteJavascript(),
     maybeShowNavigationBanner = Some(NavigationBannerInfo(request.ern, request.messageStatistics.map(_.countOfNewMessages), None))
 ) {
 

--- a/app/views/prevalidateTrader/PrevalidateExciseProductCodeView.scala.html
+++ b/app/views/prevalidateTrader/PrevalidateExciseProductCodeView.scala.html
@@ -14,10 +14,9 @@
  * limitations under the License.
  *@
 
+@import models.requests.UserAnswersRequest
 @import uk.gov.hmrc.govukfrontend.views.Implicits.RichSelect
 @import uk.gov.hmrc.hmrcfrontend.views.viewmodels.accessibleautocomplete.AccessibleAutocomplete
-@import views.html.helper.CSPNonce
-@import models.requests.UserAnswersRequest
 
 @this(
         layout: templates.Layout,
@@ -38,8 +37,7 @@
 @(form: Form[_], action: Call, selectOptions: Seq[SelectItem], indexOfDocument: Index)(implicit request: UserAnswersRequest[_], messages: Messages)
 
 @scripts = {
-@autocompleteJavascript()
-    <script @CSPNonce.attr src='@controllers.routes.Assets.versioned("javascripts/autocomplete.min.js")'></script>
+    @autocompleteJavascript()
 }
 
 @errorMessage = @{


### PR DESCRIPTION
Corrected use of the autocomplete component as detailed at https://github.com/hmrc/play-frontend-hmrc/blob/v8.5.0/README.md#adding-accessible-autocomplete-to-a-select-input by removing the hardcoded `autocomplete.min.js` script

